### PR TITLE
feat(agent): add ask_user tool for agent-to-user question suspension

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# Engineering Principles
+
+**Keep code simple: avoid overly long files and functions to manage complexity.** When a file exceeds ~400 lines or a function exceeds ~80 lines, consider splitting it. Break complex logic into small, focused units to reduce cognitive load.

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
@@ -21,7 +21,11 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.session.Session;
 import io.agentscope.core.skill.SkillBox;
 import io.agentscope.core.tool.Toolkit;
@@ -30,6 +34,7 @@ import io.github.malonetalk.agent.models.ModelProperties;
 import io.github.malonetalk.agent.skill.SkillLoaderService;
 import io.github.malonetalk.agent.tools.MarkAgentTool;
 import io.github.malonetalk.convertor.EventConverter;
+import io.github.malonetalk.dto.ChatRequest;
 import io.github.malonetalk.dto.ChatStreamEvent;
 import io.github.malonetalk.utils.MsgUtils;
 import jakarta.annotation.PostConstruct;
@@ -75,13 +80,30 @@ public class AgentService {
         return MsgUtils.getTextContent(response);
     }
 
-    public Flux<ChatStreamEvent> chatStream(String sessionId, String userInput) {
+    public Flux<ChatStreamEvent> chatStream(
+            String sessionId, String userInput, List<ChatRequest.ToolResultInput> toolResults) {
         ReActAgent agent = createAgent();
 
         Session session = sessionService.getOrCreateSession(sessionId);
         agent.loadIfExists(session, sessionId);
 
-        Msg userMsg = Msg.builder().textContent(userInput).build();
+        Msg userMsg;
+        if (toolResults != null && !toolResults.isEmpty()) {
+            List<ContentBlock> blocks =
+                    toolResults.stream()
+                            .<ContentBlock>map(
+                                    tr ->
+                                            ToolResultBlock.builder()
+                                                    .id(tr.toolCallId())
+                                                    .name(tr.toolName())
+                                                    .output(TextBlock.builder().text(tr.output()).build())
+                                                    .build())
+                            .toList();
+            userMsg = Msg.builder().role(MsgRole.TOOL).content(blocks).build();
+        } else {
+            String text = userInput != null ? userInput : "";
+            userMsg = Msg.builder().textContent(text).build();
+        }
 
         StreamOptions streamOptions =
                 StreamOptions.builder()
@@ -105,6 +127,7 @@ public class AgentService {
                 .skillBox(skillBox)
                 .memory(new InMemoryMemory())
                 .maxIters(10)
+                .enablePendingToolRecovery(true)
                 .build();
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
@@ -96,7 +96,10 @@ public class AgentService {
                                             ToolResultBlock.builder()
                                                     .id(tr.toolCallId())
                                                     .name(tr.toolName())
-                                                    .output(TextBlock.builder().text(tr.output()).build())
+                                                    .output(
+                                                            TextBlock.builder()
+                                                                    .text(tr.output())
+                                                                    .build())
                                                     .build())
                             .toList();
             userMsg = Msg.builder().role(MsgRole.TOOL).content(blocks).build();

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/AskUserTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/AskUserTool.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.agent.tools;
+
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import io.agentscope.core.tool.ToolSuspendException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AskUserTool implements MarkAgentTool {
+
+    @Tool(name = "ask_user", description = "当你不确定某个操作或需要用户确认时，调用此工具向用户提问。用户回答后你会收到回复并继续执行。")
+    public String askUser(
+            @ToolParam(name = "question", description = "要向用户询问的问题") String question) {
+        log.info("Agent asks user: {}", question);
+        throw new ToolSuspendException(question);
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/controller/AgentController.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/controller/AgentController.java
@@ -56,18 +56,8 @@ public class AgentController {
     @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<ChatStreamEvent>> chatStream(
             @Valid @RequestBody ChatRequest request) {
-        String sessionId = request.sessionId();
-        if (sessionId == null || sessionId.isEmpty()) {
-            sessionId = "default";
-        }
-
-        String message = request.message();
-        if (message == null) {
-            message = "";
-        }
-
         return agentService
-                .chatStream(sessionId, message)
+                .chatStream(request.sessionId(), request.message(), request.toolResults())
                 .map(
                         event ->
                                 ServerSentEvent.<ChatStreamEvent>builder()

--- a/data-agent-backend/src/main/java/io/github/malonetalk/convertor/EventConverter.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/convertor/EventConverter.java
@@ -31,12 +31,14 @@ import io.github.malonetalk.dto.ChatStreamEvent.ToolResultInfo;
 import io.github.malonetalk.enums.ChatStreamEventType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class EventConverter {
 
+    // TODO 2026/05/26后期优化下当前map函数的代码提高可读性和维护性
     public static List<ChatStreamEvent> map(Event event) {
         Msg msg = event.getMessage();
         String messageId = msg.getId();
@@ -110,15 +112,28 @@ public class EventConverter {
                                 new ToolCallInfo(tub.getId(), tub.getName(), tub.getInput()),
                                 null));
             } else if (block instanceof ToolResultBlock trb) {
-                String outputText = extractOutputText(trb);
-                results.add(
-                        new ChatStreamEvent(
-                                ChatStreamEventType.TOOL_RESULT,
-                                messageId,
-                                isLast,
-                                null,
-                                null,
-                                new ToolResultInfo(trb.getId(), trb.getName(), outputText)));
+                if (trb.isSuspended() && "ask_user".equals(trb.getName())) {
+                    String questionText = extractOutputText(trb);
+                    results.add(
+                            new ChatStreamEvent(
+                                    ChatStreamEventType.QUESTION,
+                                    messageId,
+                                    isLast,
+                                    questionText,
+                                    new ToolCallInfo(trb.getId(), trb.getName(), Map.of()),
+                                    null));
+                } else {
+                    String outputText = extractOutputText(trb);
+                    results.add(
+                            new ChatStreamEvent(
+                                    ChatStreamEventType.TOOL_RESULT,
+                                    messageId,
+                                    isLast,
+                                    null,
+                                    null,
+                                    new ToolResultInfo(
+                                            trb.getId(), trb.getName(), outputText, trb.isSuspended())));
+                }
             } else if (block instanceof TextBlock tb) {
                 String text = tb.getText();
                 if (text != null && !text.isEmpty()) {

--- a/data-agent-backend/src/main/java/io/github/malonetalk/convertor/EventConverter.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/convertor/EventConverter.java
@@ -132,7 +132,10 @@ public class EventConverter {
                                     null,
                                     null,
                                     new ToolResultInfo(
-                                            trb.getId(), trb.getName(), outputText, trb.isSuspended())));
+                                            trb.getId(),
+                                            trb.getName(),
+                                            outputText,
+                                            trb.isSuspended())));
                 }
             } else if (block instanceof TextBlock tb) {
                 String text = tb.getText();

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChatRequest.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChatRequest.java
@@ -18,7 +18,12 @@
 package io.github.malonetalk.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 public record ChatRequest(
         @NotBlank(message = "sessionId 不能为空") String sessionId,
-        @NotBlank(message = "message 不能为空") String message) {}
+        String message,
+        List<ToolResultInput> toolResults) {
+
+    public record ToolResultInput(String toolCallId, String toolName, String output) {}
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChatStreamEvent.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChatStreamEvent.java
@@ -32,5 +32,10 @@ public record ChatStreamEvent(
 
     public record ToolCallInfo(String id, String name, Map<String, Object> input) {}
 
-    public record ToolResultInfo(String id, String name, String output) {}
+    public record ToolResultInfo(String id, String name, String output, boolean suspended) {
+
+        public ToolResultInfo(String id, String name, String output) {
+            this(id, name, output, false);
+        }
+    }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/enums/ChatStreamEventType.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/enums/ChatStreamEventType.java
@@ -26,7 +26,8 @@ public enum ChatStreamEventType {
     TOOL_CALL("tool_call"),
     TOOL_RESULT("tool_result"),
     THINKING("thinking"),
-    TEXT("text");
+    TEXT("text"),
+    QUESTION("question");
 
     private final String code;
 

--- a/data-agent-frontend/src/api/agent.ts
+++ b/data-agent-frontend/src/api/agent.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export type ChatStreamEventType = 'summary' | 'tool_call' | 'tool_result' | 'thinking' | 'text';
+export type ChatStreamEventType = 'summary' | 'tool_call' | 'tool_result' | 'thinking' | 'text' | 'question';
 
 export interface ToolCallInfo {
   id: string;
@@ -26,6 +26,12 @@ export interface ToolCallInfo {
 export interface ToolResultInfo {
   id: string;
   name: string;
+  output: string;
+}
+
+export interface ToolResultInput {
+  toolCallId: string;
+  toolName: string;
   output: string;
 }
 
@@ -47,7 +53,8 @@ export interface SessionInfo {
 
 export interface ChatRequest {
   sessionId: string;
-  message: string;
+  message?: string;
+  toolResults?: ToolResultInput[];
 }
 
 export interface TurnItem {

--- a/data-agent-frontend/src/api/agent.ts
+++ b/data-agent-frontend/src/api/agent.ts
@@ -15,7 +15,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export type ChatStreamEventType = 'summary' | 'tool_call' | 'tool_result' | 'thinking' | 'text' | 'question';
+export type ChatStreamEventType =
+  | 'summary'
+  | 'tool_call'
+  | 'tool_result'
+  | 'thinking'
+  | 'text'
+  | 'question';
 
 export interface ToolCallInfo {
   id: string;

--- a/data-agent-frontend/src/components/chat/ChatInput.vue
+++ b/data-agent-frontend/src/components/chat/ChatInput.vue
@@ -18,8 +18,11 @@
 <script setup lang="ts">
   import { ref, nextTick } from 'vue';
 
+  import type { PendingQuestion } from '@/composables/useAgentChat';
+
   const props = defineProps<{
     isStreaming: boolean;
+    pendingQuestion: PendingQuestion | null;
   }>();
 
   const emit = defineEmits<{
@@ -63,11 +66,21 @@
 
 <template>
   <div class="chat-input">
+    <div v-if="props.pendingQuestion && !isStreaming" class="chat-input__question-banner">
+      <span class="chat-input__question-label">Agent 提问：</span>
+      <span class="chat-input__question-text">{{ props.pendingQuestion.question }}</span>
+    </div>
     <textarea
       ref="textareaRef"
       v-model="inputText"
       class="chat-input__textarea"
-      :placeholder="isStreaming ? '正在回复中...' : '输入消息，Enter 发送，Shift+Enter 换行'"
+      :placeholder="
+        props.pendingQuestion && !isStreaming
+          ? '输入你的回答，Enter 发送...'
+          : isStreaming
+            ? '正在回复中...'
+            : '输入消息，Enter 发送，Shift+Enter 换行'
+      "
       :disabled="isStreaming"
       rows="1"
       @input="autoResize"
@@ -91,11 +104,30 @@
 <style scoped>
   .chat-input {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-end;
     gap: 10px;
     padding: 16px 20px;
     background: #fff;
     border-top: 1px solid #e5e7eb;
+  }
+
+  .chat-input__question-banner {
+    width: 100%;
+    padding: 8px 14px;
+    background: #fffbeb;
+    border: 1px solid #fcd34d;
+    border-radius: 8px;
+    font-size: 13px;
+    color: #92400e;
+  }
+
+  .chat-input__question-label {
+    font-weight: 600;
+  }
+
+  .chat-input__question-text {
+    color: #78350f;
   }
 
   .chat-input__textarea {

--- a/data-agent-frontend/src/components/chat/TracePanel.vue
+++ b/data-agent-frontend/src/components/chat/TracePanel.vue
@@ -63,6 +63,7 @@
     thinking: { label: 'Thought' },
     tool_call: { label: 'Action' },
     tool_result: { label: 'Observation' },
+    question: { label: 'Question' },
   };
 
   function getStepRenderer(type: ChatStreamEventType): StepRenderer {
@@ -70,15 +71,24 @@
   }
 
   function stepLabel(step: TraceStep): string {
+    if (step.type === 'tool_call' && step.toolCall?.name === 'ask_user') {
+      return '[向用户提问]';
+    }
     return `[${getStepRenderer(step.type).label}]`;
   }
 
   function stepContent(step: TraceStep): string {
     if (step.type === 'tool_call' && step.toolCall) {
+      if (step.toolCall.name === 'ask_user') {
+        return (step.toolCall.input.question as string) ?? '等待用户输入...';
+      }
       return `调用工具: ${step.toolCall.name}`;
     }
     if (step.type === 'tool_result' && step.toolResult) {
       return `工具 ${step.toolResult.name} 返回结果`;
+    }
+    if (step.type === 'question') {
+      return `等待用户回答: ${step.content ?? ''}`;
     }
     return step.content ?? '';
   }
@@ -89,6 +99,11 @@
     } catch {
       return String(obj);
     }
+  }
+
+  function displayMultiline(text: string | null): string {
+    if (!text) return '';
+    return text.replace(/\\n/g, '\n');
   }
 </script>
 
@@ -108,14 +123,14 @@
         :class="`trace-step--${step.type}`"
       >
         <span class="trace-step__label">{{ stepLabel(step) }}</span>
-        <span class="trace-step__content">{{ stepContent(step) }}</span>
+        <span class="trace-step__content">{{ displayMultiline(stepContent(step)) }}</span>
         <div v-if="step.type === 'tool_call' && step.toolCall" class="trace-step__code">
           <div class="code-label">Input:</div>
-          <pre class="code-block">{{ formatJson(step.toolCall.input) }}</pre>
+          <pre class="code-block">{{ displayMultiline(formatJson(step.toolCall.input)) }}</pre>
         </div>
         <div v-if="step.type === 'tool_result' && step.toolResult" class="trace-step__code">
           <div class="code-label">Output:</div>
-          <pre class="code-block">{{ step.toolResult.output }}</pre>
+          <pre class="code-block">{{ displayMultiline(step.toolResult.output) }}</pre>
         </div>
       </div>
     </div>
@@ -205,6 +220,7 @@
 
   .trace-step__content {
     color: #475569;
+    white-space: pre-wrap;
   }
 
   /* Event type color variants — extend here for new ChatStreamEventType values */
@@ -227,6 +243,13 @@
   }
   .trace-step--tool_result .trace-step__label {
     color: #16a34a;
+  }
+
+  .trace-step--question {
+    color: #d97706;
+  }
+  .trace-step--question .trace-step__label {
+    color: #d97706;
   }
 
   .trace-step--summary {

--- a/data-agent-frontend/src/composables/useAgentChat.ts
+++ b/data-agent-frontend/src/composables/useAgentChat.ts
@@ -18,6 +18,12 @@
 import { ref, shallowRef } from 'vue';
 import { streamChat, fetchSessionHistory, type ChatStreamEventType } from '@/api/agent';
 
+export interface PendingQuestion {
+  toolCallId: string;
+  toolName: string;
+  question: string;
+}
+
 export interface TraceStep {
   type: ChatStreamEventType;
   content: string | null;
@@ -48,6 +54,7 @@ export function useAgentChat(initialSessionId?: string) {
   const isStreaming = ref(false);
   const sessionId = ref(initialSessionId || generateSessionId());
   const abortController = shallowRef<AbortController | null>(null);
+  const pendingQuestion = ref<PendingQuestion | null>(null);
 
   function addUserMessage(text: string): ChatMessage {
     const msg: ChatMessage = {
@@ -111,18 +118,24 @@ export function useAgentChat(initialSessionId?: string) {
     abortController.value = controller;
     let summaryStarted = false;
 
+    const pq = pendingQuestion.value;
+    pendingQuestion.value = null;
+
+    const request =
+      pq != null
+        ? {
+            sessionId: sessionId.value,
+            toolResults: [{ toolCallId: pq.toolCallId, toolName: pq.toolName, output: text }],
+          }
+        : { sessionId: sessionId.value, message: text };
+
     try {
-      for await (const event of streamChat(
-        { sessionId: sessionId.value, message: text },
-        controller.signal,
-      )) {
+      for await (const event of streamChat(request, controller.signal)) {
         updateAgentMessage(agentMsg.id, msg => {
-          // text: append to content
           if (event.type === 'text' && event.content) {
             msg.content += event.content;
           }
 
-          // summary: merge into content with a marker so the template can split and render green
           if (event.type === 'summary' && event.content) {
             if (!summaryStarted) {
               msg.content += '\n\nSummary：\n' + event.content;
@@ -132,7 +145,6 @@ export function useAgentChat(initialSessionId?: string) {
             }
           }
 
-          // thinking: merge consecutive thought chunks into one step
           if (event.type === 'thinking') {
             const lastStep = msg.traceSteps[msg.traceSteps.length - 1];
             if (lastStep && lastStep.type === 'thinking') {
@@ -140,27 +152,25 @@ export function useAgentChat(initialSessionId?: string) {
             } else {
               msg.traceSteps = [
                 ...msg.traceSteps,
-                {
-                  type: event.type,
-                  content: event.content,
-                  toolCall: event.toolCall,
-                  toolResult: event.toolResult,
-                },
+                { type: event.type, content: event.content, toolCall: event.toolCall, toolResult: event.toolResult },
               ];
             }
           }
 
-          // tool_call / tool_result: push as individual trace steps
           if (event.type === 'tool_call' || event.type === 'tool_result') {
             msg.traceSteps = [
               ...msg.traceSteps,
-              {
-                type: event.type,
-                content: event.content,
-                toolCall: event.toolCall,
-                toolResult: event.toolResult,
-              },
+              { type: event.type, content: event.content, toolCall: event.toolCall, toolResult: event.toolResult },
             ];
+
+            if (event.type === 'tool_call' && event.toolCall?.name === 'ask_user') {
+              pendingQuestion.value = {
+                toolCallId: event.toolCall.id,
+                toolName: event.toolCall.name,
+                question: (event.toolCall.input.question as string) ?? '',
+              };
+              msg.isStreaming = false;
+            }
           }
 
           if (event.isLast) {
@@ -202,6 +212,7 @@ export function useAgentChat(initialSessionId?: string) {
     messages,
     isStreaming,
     sessionId,
+    pendingQuestion,
     loadHistory,
     sendMessage,
     stopStreaming,

--- a/data-agent-frontend/src/composables/useAgentChat.ts
+++ b/data-agent-frontend/src/composables/useAgentChat.ts
@@ -152,7 +152,12 @@ export function useAgentChat(initialSessionId?: string) {
             } else {
               msg.traceSteps = [
                 ...msg.traceSteps,
-                { type: event.type, content: event.content, toolCall: event.toolCall, toolResult: event.toolResult },
+                {
+                  type: event.type,
+                  content: event.content,
+                  toolCall: event.toolCall,
+                  toolResult: event.toolResult,
+                },
               ];
             }
           }
@@ -160,7 +165,12 @@ export function useAgentChat(initialSessionId?: string) {
           if (event.type === 'tool_call' || event.type === 'tool_result') {
             msg.traceSteps = [
               ...msg.traceSteps,
-              { type: event.type, content: event.content, toolCall: event.toolCall, toolResult: event.toolResult },
+              {
+                type: event.type,
+                content: event.content,
+                toolCall: event.toolCall,
+                toolResult: event.toolResult,
+              },
             ];
 
             if (event.type === 'tool_call' && event.toolCall?.name === 'ask_user') {

--- a/data-agent-frontend/src/views/chat/ChatView.vue
+++ b/data-agent-frontend/src/views/chat/ChatView.vue
@@ -26,8 +26,16 @@
   const route = useRoute();
   const router = useRouter();
 
-  const { messages, isStreaming, sessionId, sendMessage, stopStreaming, newSession, loadHistory } =
-    useAgentChat();
+  const {
+    messages,
+    isStreaming,
+    sessionId,
+    pendingQuestion,
+    sendMessage,
+    stopStreaming,
+    newSession,
+    loadHistory,
+  } = useAgentChat();
 
   const messagesContainer = ref<{ scrollTop: number; scrollHeight: number }>();
   const sessionListRef = ref<InstanceType<typeof SessionList>>();
@@ -137,7 +145,12 @@
         <div v-if="isStreaming && messages.length === 0" class="chat-view__empty">思考中...</div>
       </div>
 
-      <ChatInput :is-streaming="isStreaming" @send="handleSend" @stop="stopStreaming" />
+      <ChatInput
+        :is-streaming="isStreaming"
+        :pending-question="pendingQuestion"
+        @send="handleSend"
+        @stop="stopStreaming"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
- Add AskUserTool that suspends agent via ToolSuspendException to ask user
- Add QUESTION event type for agent-originated questions
- Update ChatRequest to support optional toolResults for resuming suspended calls
- Add ChatInput question banner UI with pending question state
- Wire pendingQuestion flow through useAgentChat composable
- Add toolResults parameter to AgentController.chatStream for tool resumption
- Add CLAUDE.md content with simplicity principle