### PR TITLE
docs: highlight core design in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,29 @@
 - **自然语言查数**：基于 LLM + ReAct 工具调用，把自然语言转为 SQL 并在目标库执行，全程流式输出。
 - **Python 数据分析**：对查询结果自动执行统计分析（相关性、回归、分布检验），补齐 SQL 在复杂统计计算上的短板。
 - **多模型可切换**：内置 OpenAI / Ollama / 通义 DashScope / Anthropic 等提供商，换底座模型不影响已沉淀的业务知识。
-- **多数据源**：支持查询 MySQL、PostgreSQL、Oracle。
-- **语义层**：域（Domain）/ 逻辑表 / 逻辑列 / 表关系 / 指标口径的业务映射，让 LLM 真正"懂业务"。
+- **多数据源（JDBC 抽象）**：数据读取与执行完全基于 JDBC 标准 API，因此支持**任意 JDBC 兼容数据库**——MySQL / PostgreSQL / Oracle 已验证，ClickHouse / SQL Server / 达梦 / OceanBase / SQLite 等只需引入对应驱动即可接入。
+- **语义层（无向量召回）**：以"域（Domain）"组织表，由 LLM 在工具调用时**推理出业务问题所属域、主动选表**，而非向量相似度召回——更精准、更稳定，也无需维护任何 embedding 索引。维度包括逻辑表 / 逻辑列 / 表关系 / 指标口径的业务映射。
 - **会话式分析**：SSE 流式回答，会话历史可追溯、可调试。
 - **报表生成**：内置报表工具与配套前端报表视图。
 - **Skill 系统**：从文件系统 / Git / Nacos 多源加载可复用的查询流程（"已验证查询模式"）。
 - **MCP 集成**：可注册并连接外部 MCP Server，把外部工具纳入 Agent 工具箱。
+
+## 💡 核心设计亮点
+
+### 1. 语义层召回：用模型推理替代向量检索
+
+传统 Text-to-SQL 方案通常用向量相似度从成百上千张表里"召回"候选表，但向量召回既容易误召回 / 漏召回，又要额外维护 embedding 模型与向量索引。
+
+Data Agent 反其道而行——**不引入任何向量检索**。语义层把表组织成"域（Domain）"，LLM 在工具调用时直接**推理出业务问题属于哪个域**，再由 `get_tables` 工具按域精确返回该域下的表（`GetTablesTool` → `TableSemanticService.listMergedTablesByDomains`）。
+
+理由很直接：判断"上个月各区域销售额"属于"销售域"这件事，让模型去理解语义，比让向量去算余弦相似度**更准、更稳**，而且零额外依赖、零索引维护成本。
+
+### 2. 数据源层：纯 JDBC 抽象，兼容一切关系型库
+
+- `SchemaReader` 完全基于 JDBC 标准 `DatabaseMetaData` 读取表 / 列 / 主键，不绑定任何数据库方言；
+- `SqlExecutor` 只使用 `Connection` / `PreparedStatement` / `ResultSet` 执行查询，并叠加 SELECT 校验、自动 `LIMIT` 等安全护栏。
+
+整条"读取表结构 → 执行查询"的路径都跑在 JDBC 标准 API 上，因此只要目标库**提供 JDBC 驱动**，Data Agent 就能接入。支持范围不局限于 MySQL / PostgreSQL / Oracle——ClickHouse、SQL Server、达梦、OceanBase、SQLite 等任意 JDBC 兼容数据库在理论上都可直接支持，引入对应驱动即可。
 
 ## 🏗️ 架构速览
 
@@ -34,11 +51,11 @@
    LLM(可切换底座)              工具集(SQL/Schema/Python/反问/报表)      语义层 (MySQL)
                             │
                             ▼
-                     目标数据源 (MySQL / PG / Oracle)
+                     目标数据源 (任意 JDBC 兼容数据库)
 ```
 
 - **元数据库**（存放语义层、数据源、会话、MCP 配置等）使用 MySQL。
-- **被查询的业务库**可以是 MySQL / PostgreSQL / Oracle。
+- **被查询的业务库**可以是任何提供 JDBC 驱动的数据库（MySQL / PostgreSQL / Oracle 已验证，其余 JDBC 兼容库引入驱动即可）。
 
 完整架构与请求流转见 [docs/architecture.md](docs/architecture.md)。
 


### PR DESCRIPTION
Add a "核心设计亮点" section explaining why the semantic layer uses LLM domain inference instead of vector retrieval, and why the data-source layer is pure JDBC (DatabaseMetaData + standard Connection execution) so any JDBC-compatible database plugs in by adding a driver. Rephrase the multi-datasource and semantic-layer bullets to match.