### PR TITLE
fix(frontend): render interactive tools via registry instead of hardcoded ask_user

### DIFF
--- a/data-agent-frontend/src/composables/useAgentChat.ts
+++ b/data-agent-frontend/src/composables/useAgentChat.ts
@@ -17,6 +17,7 @@
 
 import { ref, shallowRef } from 'vue';
 import { streamChat, fetchSessionHistory, type ChatStreamEventType } from '@/api/agent';
+import { INTERACTIVE_TOOLS, isInteractiveTool } from '@/utils/interactiveTools';
 
 export interface PendingQuestion {
   toolCallId: string;
@@ -178,11 +179,12 @@ export function useAgentChat(initialSessionId?: string) {
               },
             ];
 
-            if (event.type === 'tool_call' && event.toolCall?.name === 'ask_user') {
+            if (event.type === 'tool_call' && isInteractiveTool(event.toolCall?.name)) {
+              const def = INTERACTIVE_TOOLS[event.toolCall!.name];
               pendingQuestion.value = {
-                toolCallId: event.toolCall.id,
-                toolName: event.toolCall.name,
-                question: (event.toolCall.input.question as string) ?? '',
+                toolCallId: event.toolCall!.id,
+                toolName: event.toolCall!.name,
+                question: (event.toolCall!.input[def.questionField] as string) ?? '',
               };
               msg.isStreaming = false;
             }

--- a/data-agent-frontend/src/utils/interactiveTools.ts
+++ b/data-agent-frontend/src/utils/interactiveTools.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+
+/**
+ * 交互工具定义 —— 对应后端一个 throw ToolSuspendException 的工具方法。
+ * 新增交互表单只需在此注册表加一条配置，无需修改 TracePanel / useAgentChat。
+ */
+export interface InteractiveToolDef {
+  /** tool_call 步骤的标签，如 "向用户提问" */
+  label: string;
+  /** 从 toolCall.input 中取展示文本的字段名 */
+  questionField: string;
+  /** tool_result 步骤的标签，如 "用户回答" */
+  resultLabel: string;
+}
+
+/** 所有交互工具的注册表，key 为工具名（与后端 @Tool.name 一致） */
+export const INTERACTIVE_TOOLS: Record<string, InteractiveToolDef> = {
+  ask_user: {
+    label: '向用户提问',
+    questionField: 'question',
+    resultLabel: '用户回答',
+  },
+};
+
+/** 判断工具名是否为已注册的交互工具 */
+export function isInteractiveTool(toolName: string | null | undefined): boolean {
+  return toolName != null && toolName in INTERACTIVE_TOOLS;
+}

--- a/data-agent-frontend/src/views/chat/components/TracePanel.vue
+++ b/data-agent-frontend/src/views/chat/components/TracePanel.vue
@@ -19,6 +19,7 @@
   import { ref, computed } from 'vue';
   import type { TraceStep, ChatMessage } from '@/composables/useAgentChat';
   import type { ChatStreamEventType } from '@/api/agent';
+  import { INTERACTIVE_TOOLS, isInteractiveTool } from '@/utils/interactiveTools';
 
   const props = defineProps<{
     message: ChatMessage;
@@ -75,20 +76,27 @@
   }
 
   function stepLabel(step: TraceStep): string {
-    if (step.type === 'tool_call' && step.toolCall?.name === 'ask_user') {
-      return '[向用户提问]';
+    if (step.type === 'tool_call' && isInteractiveTool(step.toolCall?.name)) {
+      return `[${INTERACTIVE_TOOLS[step.toolCall!.name].label}]`;
+    }
+    if (step.type === 'tool_result' && isInteractiveTool(step.toolResult?.name)) {
+      return `[${INTERACTIVE_TOOLS[step.toolResult!.name].resultLabel}]`;
     }
     return `[${getStepRenderer(step.type).label}]`;
   }
 
   function stepContent(step: TraceStep): string {
     if (step.type === 'tool_call' && step.toolCall) {
-      if (step.toolCall.name === 'ask_user') {
-        return (step.toolCall.input.question as string) ?? '等待用户输入...';
+      if (isInteractiveTool(step.toolCall.name)) {
+        const def = INTERACTIVE_TOOLS[step.toolCall.name];
+        return (step.toolCall.input[def.questionField] as string) ?? '等待用户输入...';
       }
       return `调用工具: ${step.toolCall.name}`;
     }
     if (step.type === 'tool_result' && step.toolResult) {
+      if (isInteractiveTool(step.toolResult.name)) {
+        return step.toolResult.output || '(无内容)';
+      }
       return `工具 ${step.toolResult.name} 返回结果`;
     }
     if (step.type === 'question') {
@@ -135,7 +143,14 @@
           <div class="code-label">Input:</div>
           <pre class="code-block">{{ displayMultiline(formatJson(step.toolCall.input)) }}</pre>
         </div>
-        <div v-if="step.type === 'tool_result' && step.toolResult" class="trace-step__code">
+        <div
+          v-if="
+            step.type === 'tool_result' &&
+            step.toolResult &&
+            !isInteractiveTool(step.toolResult.name)
+          "
+          class="trace-step__code"
+        >
           <div class="code-label">Output:</div>
           <pre class="code-block">{{ displayMultiline(step.toolResult.output) }}</pre>
         </div>


### PR DESCRIPTION
close #65

Replace scattered `=== 'ask_user'` checks in useAgentChat and TracePanel with an interactive-tools registry (interactiveTools.ts). Both tool_call and tool_result of interactive tools now render consistently, so the ask_user question/answer pair shows correctly when re-entering a historical session. Adding a new interactive tool is now a one-line registry entry.