### PR TITLE
fix(exception): sanitize leaked error messages and log 4xx client errors

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
@@ -138,9 +138,7 @@ public class AgentService {
 
     private Flux<ChatStreamEvent> toErrorEvent(Throwable exception) {
         ErrorResponse errorResponse = exceptionResponseMapper.resolve(exception);
-        if (errorResponse.isServerError()) {
-            log.error("Agent stream failed", exception);
-        }
+        exceptionResponseMapper.logMapped(log, exception, errorResponse);
         return Flux.just(
                 ChatStreamEvent.builder()
                         .type(ChatStreamEventType.ERROR)

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/ExecuteSqlTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/ExecuteSqlTool.java
@@ -48,7 +48,6 @@ public class ExecuteSqlTool implements MarkAgentTool {
             @ToolParam(name = "sql", description = "The SELECT SQL query statement to execute")
                     String sql) {
         return toolExceptionMapper.run(
-                "execute SQL",
                 () -> {
                     Datasource datasource =
                             dataSourceService

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GenerateReportTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GenerateReportTool.java
@@ -88,7 +88,6 @@ public class GenerateReportTool implements MarkAgentTool {
         }
         String reportSessionId = sessionId;
         return toolExceptionMapper.run(
-                "generate report",
                 () ->
                         ToolResultBlock.text(
                                 ToolCallConstants.SUCCESS_PREFIX

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetDomainsTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetDomainsTool.java
@@ -39,7 +39,6 @@ public class GetDomainsTool implements MarkAgentTool {
                             + " what domains are available before querying tables.")
     public ToolResultBlock getDomains() {
         return toolExceptionMapper.run(
-                "get domains",
                 () ->
                         ToolResultBlock.text(
                                 JsonUtils.getJsonCodec().toJson(domainService.listDomainNames())));

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTableSchemaTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTableSchemaTool.java
@@ -55,7 +55,6 @@ public class GetTableSchemaTool implements MarkAgentTool {
             @ToolParam(name = "table_name", description = "The table name to query schema for")
                     String tableName) {
         return toolExceptionMapper.run(
-                "get table schema",
                 () -> {
                     Datasource datasource =
                             dataSourceService

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTablesTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTablesTool.java
@@ -60,7 +60,6 @@ public class GetTablesTool implements MarkAgentTool {
                             required = false)
                     List<String> domains) {
         return toolExceptionMapper.run(
-                "get tables",
                 () -> {
                     Datasource dataSource =
                             dataSourceService

--- a/data-agent-backend/src/main/java/io/github/malonetalk/exception/ExceptionResponseMapper.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/exception/ExceptionResponseMapper.java
@@ -18,6 +18,8 @@
 package io.github.malonetalk.exception;
 
 import io.github.malonetalk.common.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.TransientDataAccessException;
@@ -29,6 +31,7 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /** 将已知异常统一映射为 ErrorCode 和对外提示，供 HTTP、SSE、agent tool 共用。 */
 @Component
+@Slf4j
 public class ExceptionResponseMapper {
 
     /** 统一异常映射入口；沿 cause 链逐层识别，被框架包装过的异常仍能保留原 ErrorCode。 */
@@ -48,9 +51,10 @@ public class ExceptionResponseMapper {
             return fromBusinessException(businessException);
         }
         if (current instanceof IllegalArgumentException) {
-            // 未迁移的裸参数断言统一视为请求参数错误，
-            // 避免这些调用点落成 500。
-            return of(ErrorCode.BAD_REQUEST, current.getMessage());
+            // 未迁移的裸参数断言统一视为请求参数错误，避免落成 500；
+            // 原始 message 可能含连接串等内部细节，只进日志不进响应体。
+            log.debug("IllegalArgumentException mapped to BAD_REQUEST: {}", current.getMessage());
+            return of(ErrorCode.BAD_REQUEST);
         }
         if (current instanceof DataIntegrityViolationException) {
             return of(ErrorCode.DATA_CONFLICT);
@@ -89,6 +93,18 @@ public class ExceptionResponseMapper {
     /** 保留业务异常携带的错误码，同时统一处理空 message 的回退。 */
     private ErrorResponse fromBusinessException(BusinessException exception) {
         return of(exception.getErrorCode(), exception.getMessage());
+    }
+
+    /** 统一日志策略：5xx 记完整堆栈，4xx 记一行摘要；HTTP、SSE、tool 三出口共用。 */
+    public void logMapped(Logger logger, Throwable exception, ErrorResponse errorResponse) {
+        if (errorResponse.isServerError()) {
+            logger.error("Mapped server exception", exception);
+        } else {
+            logger.warn(
+                    "Mapped client error: {} - {}",
+                    errorResponse.errorCode(),
+                    errorResponse.message());
+        }
     }
 
     /** 对外错误文案不能是空值，避免前端拿到不可展示的 message。 */

--- a/data-agent-backend/src/main/java/io/github/malonetalk/exception/GlobalExceptionHandler.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/exception/GlobalExceptionHandler.java
@@ -87,13 +87,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Result<Object>> handleException(Exception exception) {
         ErrorResponse errorResponse = exceptionResponseMapper.resolve(exception);
-        logMappedException(exception, errorResponse);
+        exceptionResponseMapper.logMapped(log, exception, errorResponse);
         return response(errorResponse);
     }
 
     private String resolveBadRequestMessage(Exception exception) {
         if (exception instanceof HttpMessageNotReadableException) {
             return "Malformed request body.";
+        }
+        if (exception instanceof MethodArgumentTypeMismatchException typeMismatch) {
+            // 转换异常消息含内部类型名（如 java.lang.Long），对外只暴露参数名。
+            return "Invalid value for parameter '" + typeMismatch.getName() + "'.";
         }
         return exception.getMessage() == null
                 ? "Invalid request parameters."
@@ -129,19 +133,14 @@ public class GlobalExceptionHandler {
         return new FieldValidationError(field, message);
     }
 
-    /** ConstraintViolation 的路径可能带方法名或对象名前缀，这里只保留最后一级字段。 */
+    /** ConstraintViolation 的路径形如 "tableName"（参数直接约束）或 "arg0.address.city"（嵌套 DTO），
+     *  去掉第一段参数/方法前缀，保留嵌套字段路径供前端定位。 */
     private String resolveConstraintField(String propertyPath) {
-        int separatorIndex = propertyPath.lastIndexOf('.');
+        int separatorIndex = propertyPath.indexOf('.');
         if (separatorIndex < 0 || separatorIndex == propertyPath.length() - 1) {
             return propertyPath;
         }
         return propertyPath.substring(separatorIndex + 1);
-    }
-
-    private void logMappedException(Exception exception, ErrorResponse errorResponse) {
-        if (errorResponse.isServerError()) {
-            log.error("Mapped server exception", exception);
-        }
     }
 
     /** 按错误码和指定文案组装 HTTP 响应。 */

--- a/data-agent-backend/src/main/java/io/github/malonetalk/exception/ToolExceptionMapper.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/exception/ToolExceptionMapper.java
@@ -36,7 +36,7 @@ public class ToolExceptionMapper {
 
     private final ExceptionResponseMapper exceptionResponseMapper;
 
-    public ToolResultBlock run(String actionName, ToolAction action) {
+    public ToolResultBlock run(ToolAction action) {
         try {
             return action.run();
         } catch (ToolSuspendException exception) {
@@ -44,9 +44,7 @@ public class ToolExceptionMapper {
             throw exception;
         } catch (Exception exception) {
             ErrorResponse errorResponse = exceptionResponseMapper.resolve(exception);
-            if (errorResponse.isServerError()) {
-                log.error("Tool action failed: {}", actionName, exception);
-            }
+            exceptionResponseMapper.logMapped(log, exception, errorResponse);
             return toToolError(errorResponse);
         }
     }


### PR DESCRIPTION
 - IllegalArgumentException / MethodArgumentTypeMismatchException 不再向响应体透传原始 message（可能含连接串、内部类型名），详情进日志
 - 新增 ExceptionResponseMapper.logMapped 统一 HTTP/SSE/tool 三出口日志策略：5xx 记完整堆栈，4xx 记 warn 摘要
  - resolveConstraintField 保留嵌套字段路径（arg0.address.city），修复字段定位丢失