### PR TITLE
feat(auth): add login v1 (JWT, interceptor, admin bootstrap, frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Data Agent 反其道而行——**不引入任何向量检索**。语义层把�
 **前置依赖**：JDK 17+、Maven 3.9+、Node 18+、pnpm 8+、MySQL 8+、Python 3+（需安装 pandas、numpy、scipy）。
 
 ```bash
-# 1. 建元数据库并初始化表结构
+# 1. 建元数据库并初始化表结构（sql/ 目录下所有 .sql 文件均需执行）
 mysql -u root -p -e "CREATE DATABASE data_agent CHARACTER SET utf8mb4;"
-mysql -u root -p data_agent < sql/data_source.sql
+for f in sql/*.sql; do mysql -u root -p data_agent < "$f"; done
 
 # 2. 启动后端（默认端口 8080）
 cd data-agent-backend

--- a/data-agent-backend/pom.xml
+++ b/data-agent-backend/pom.xml
@@ -144,6 +144,25 @@
             <artifactId>jsqlparser</artifactId>
             <version>5.0</version>
         </dependency>
+
+        <!-- JWT 签发/校验（HS256）；唯一为登录引入的依赖，密码哈希走 JDK 标准库无新依赖 -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/data-agent-backend/src/main/java/io/github/malonetalk/common/ErrorCode.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/common/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     /** 请求参数格式或取值非法，但没有更细分的业务错误码。 */
     BAD_REQUEST("BAD_REQUEST", HttpStatus.BAD_REQUEST, "Invalid request parameters."),
 
+    /** 未认证：缺少或无效的凭证（token 缺失/过期/非法/用户已禁用）。 */
+    UNAUTHORIZED("UNAUTHORIZED", HttpStatus.UNAUTHORIZED, "Authentication is required."),
+
     /** Bean Validation、绑定校验等字段级参数校验失败。 */
     VALIDATION_FAILED("VALIDATION_FAILED", HttpStatus.BAD_REQUEST, "Invalid request parameters."),
 

--- a/data-agent-backend/src/main/java/io/github/malonetalk/common/UserContext.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/common/UserContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.common;
+
+/**
+ * 当前登录用户的轻量投影，由拦截器在同步请求线程放入 ThreadLocal。
+ *
+ * <p>仅承载鉴权必要字段（不含 password_hash），供管理/会话等同步 API 取用。Agent 异步链路
+ * （Reactor 弹性线程）拿不到此 ThreadLocal——权限轮次会改为通过 ToolCallContext 显式传 userId。
+ */
+public record UserContext(Integer userId, String username, String displayName) {
+
+    private static final ThreadLocal<UserContext> HOLDER = new ThreadLocal<>();
+
+    public static void set(UserContext context) {
+        HOLDER.set(context);
+    }
+
+    public static UserContext get() {
+        return HOLDER.get();
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+
+    public static UserContext require() {
+        UserContext context = HOLDER.get();
+        if (context == null) {
+            throw new IllegalStateException("No user context bound to current thread.");
+        }
+        return context;
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/config/AdminBootstrapRunner.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/config/AdminBootstrapRunner.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.config;
+
+import io.github.malonetalk.entity.SysUser;
+import io.github.malonetalk.mapper.SysUserMapper;
+import io.github.malonetalk.util.PasswordUtil;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * 启动引导：sys_user 为空时创建初始 admin 账号。
+ *
+ * <p>初始密码取自环境变量（{@code ADMIN_INIT_PASSWORD}，经 {@code admin.init-password} 注入），
+ * 不写死进代码/SQL，避免进 git 历史。登录后应立即用改密码接口换掉。
+ *
+ * <p>未配置初始密码时启动失败（fail-closed）——避免无密码 admin 账号被静默创建。
+ * role_id 暂为 0：本轮无任何权限检查，admin 仅作为首个登录账号；
+ * 「不受权限限制」语义随权限轮次 sys_role(id=1) + @AdminOnly 一起生效。
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AdminBootstrapRunner implements CommandLineRunner {
+
+    private final SysUserMapper sysUserMapper;
+
+    @Value("${admin.init-password:}")
+    private String adminInitPassword;
+
+    @Override
+    public void run(String... args) {
+        if (sysUserMapper.countAll() > 0) {
+            return;
+        }
+        if (adminInitPassword == null || adminInitPassword.isBlank()) {
+            throw new IllegalStateException(
+                    "No user exists and admin.init-password (env ADMIN_INIT_PASSWORD) is not set. "
+                            + "Configure it before first startup to bootstrap the admin account.");
+        }
+        LocalDateTime now = LocalDateTime.now();
+        SysUser admin = new SysUser();
+        admin.setUsername("admin");
+        admin.setPasswordHash(PasswordUtil.hash(adminInitPassword));
+        admin.setDisplayName("管理员");
+        admin.setRoleId(0);
+        admin.setIdpType("LOCAL");
+        admin.setIdpUserId(null);
+        admin.setStatus(1);
+        admin.setCreateTime(now);
+        admin.setUpdateTime(now);
+        sysUserMapper.insert(admin);
+        log.info(
+                "Bootstrapped initial admin account (id={}, username=admin). Change its password"
+                        + " ASAP.",
+                admin.getId());
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/config/WebMvcConfig.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/config/WebMvcConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.config;
+
+import io.github.malonetalk.interceptor.AuthInterceptor;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** 注册鉴权拦截器：覆盖 /api/**，仅放行登录接口与 Spring 错误页。 */
+@Configuration
+@AllArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/auth/login", "/error");
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/controller/AuthController.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/controller/AuthController.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.controller;
+
+import io.github.malonetalk.common.ErrorCode;
+import io.github.malonetalk.common.Result;
+import io.github.malonetalk.common.UserContext;
+import io.github.malonetalk.dto.ChangePasswordRequest;
+import io.github.malonetalk.dto.LoginRequest;
+import io.github.malonetalk.dto.LoginResponse;
+import io.github.malonetalk.dto.UserInfoResponse;
+import io.github.malonetalk.entity.SysUser;
+import io.github.malonetalk.exception.BusinessException;
+import io.github.malonetalk.mapper.SysUserMapper;
+import io.github.malonetalk.util.JwtUtil;
+import io.github.malonetalk.util.PasswordUtil;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 认证接口：登录 / 当前用户 / 改密码。
+ *
+ * <p>登录失败统一返回 401 + "用户名或密码错误"，避免用户名枚举；账号禁用单独提示。
+ */
+@RestController
+@Slf4j
+@AllArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private static final String BAD_CREDENTIALS = "用户名或密码错误";
+
+    private final SysUserMapper sysUserMapper;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/login")
+    public Result<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        SysUser user = sysUserMapper.selectByUsername(request.username());
+        // 用户不存在、外部身份源（password_hash 为空）、密码不匹配：统一文案，避免枚举用户名。
+        if (user == null
+                || user.getPasswordHash() == null
+                || !PasswordUtil.verify(request.password(), user.getPasswordHash())) {
+            throw BusinessException.of(ErrorCode.UNAUTHORIZED, BAD_CREDENTIALS);
+        }
+        if (user.getStatus() == null || user.getStatus() != 1) {
+            throw BusinessException.of(ErrorCode.UNAUTHORIZED, "账号已禁用，请联系管理员");
+        }
+        String token = jwtUtil.generate(user.getId());
+        UserInfoResponse info =
+                new UserInfoResponse(user.getId(), user.getUsername(), user.getDisplayName());
+        return Result.success(new LoginResponse(token, info));
+    }
+
+    @GetMapping("/me")
+    public Result<UserInfoResponse> me() {
+        UserContext context = UserContext.require();
+        return Result.success(
+                new UserInfoResponse(context.userId(), context.username(), context.displayName()));
+    }
+
+    @PostMapping("/change-password")
+    public Result<Boolean> changePassword(@Valid @RequestBody ChangePasswordRequest request) {
+        Integer userId = UserContext.require().userId();
+        SysUser user = sysUserMapper.selectById(userId);
+        if (user == null
+                || user.getPasswordHash() == null
+                || !PasswordUtil.verify(request.oldPassword(), user.getPasswordHash())) {
+            throw BusinessException.of(ErrorCode.BAD_REQUEST, "旧密码不正确");
+        }
+        sysUserMapper.updatePassword(
+                userId, PasswordUtil.hash(request.newPassword()), LocalDateTime.now());
+        return Result.success(true);
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChangePasswordRequest.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/ChangePasswordRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "oldPassword 不能为空") String oldPassword,
+        @NotBlank(message = "newPassword 不能为空")
+                @Size(min = 6, max = 64, message = "newPassword 长度需在 6-64 之间")
+                String newPassword) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/LoginRequest.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/LoginRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "username 不能为空") String username,
+        @NotBlank(message = "password 不能为空") String password) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/LoginResponse.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/LoginResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.dto;
+
+/** 登录成功响应：token + 用户信息（一次往返，前端无需再调 me）。 */
+public record LoginResponse(String token, UserInfoResponse user) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/UserInfoResponse.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/UserInfoResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.dto;
+
+/** 当前用户信息；角色/是否管理员字段随权限轮次补充。 */
+public record UserInfoResponse(Integer userId, String username, String displayName) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/entity/SysUser.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/entity/SysUser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.entity;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/** 系统用户。身份源抽象字段（idp_type/idp_user_id）本轮登录仅用 LOCAL，外部身份源对接后置。 */
+@Data
+public class SysUser {
+
+    private Integer id;
+    private String username;
+
+    /** PBKDF2 哈希，格式 pbkdf2$iter$salt$hash；外部身份源用户为空。 */
+    private String passwordHash;
+
+    private String displayName;
+    private Integer roleId;
+    private String idpType;
+    private String idpUserId;
+
+    /** 1=启用 0=禁用。 */
+    private Integer status;
+
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/interceptor/AuthInterceptor.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/interceptor/AuthInterceptor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.interceptor;
+
+import io.github.malonetalk.common.ErrorCode;
+import io.github.malonetalk.common.UserContext;
+import io.github.malonetalk.exception.BusinessException;
+import io.github.malonetalk.mapper.SysUserMapper;
+import io.github.malonetalk.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 鉴权拦截器：拦 /api/**，放行 /api/auth/login 与 /error。
+ *
+ * <p>解析 Authorization: Bearer → JwtUtil 取 userId → 每次请求查库（selectAuthProjection 只返回启用用户）
+ * → 放入 UserContext。token 缺失/过期/非法 或 用户被禁用 一律抛 {@link ErrorCode#UNAUTHORIZED}，
+ * 由 GlobalExceptionHandler 统一输出 401。每次查库保证禁用即时生效。
+ *
+ * <p>权限轮次再加 @AdminOnly 与表/列拦截；本轮登录后所有接口行为与现状一致。
+ */
+@Component
+@AllArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final JwtUtil jwtUtil;
+    private final SysUserMapper sysUserMapper;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Integer userId = jwtUtil.parseUserId(extractBearer(request));
+        if (userId == null) {
+            throw BusinessException.of(ErrorCode.UNAUTHORIZED, "Missing or invalid token.");
+        }
+        UserContext context = sysUserMapper.selectAuthProjection(userId);
+        if (context == null) {
+            // 用户不存在或 status=0（禁用），均视为未授权。
+            throw BusinessException.of(
+                    ErrorCode.UNAUTHORIZED, "Account is disabled or does not exist.");
+        }
+        UserContext.set(context);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler,
+            Exception ex) {
+        UserContext.clear();
+    }
+
+    private String extractBearer(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || header.isBlank()) {
+            return null;
+        }
+        String trimmed = header.trim();
+        String prefix = "Bearer ";
+        if (trimmed.length() > prefix.length()
+                && trimmed.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            return trimmed.substring(prefix.length()).trim();
+        }
+        return null;
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/mapper/SysUserMapper.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/mapper/SysUserMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.mapper;
+
+import io.github.malonetalk.common.UserContext;
+import io.github.malonetalk.entity.SysUser;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface SysUserMapper {
+
+    /** 登录校验：按用户名查 LOCAL 账号（含 password_hash）。 */
+    SysUser selectByUsername(@Param("username") String username);
+
+    SysUser selectById(@Param("id") Integer id);
+
+    /** 拦截器每次请求调用：仅取鉴权必要字段，且 status=1 才返回；禁用即时生效。 */
+    UserContext selectAuthProjection(@Param("id") Integer id);
+
+    int insert(SysUser user);
+
+    int updatePassword(
+            @Param("id") Integer id,
+            @Param("passwordHash") String passwordHash,
+            @Param("updateTime") java.time.LocalDateTime updateTime);
+
+    int countAll();
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/util/JwtUtil.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/util/JwtUtil.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 签发/校验：HS256，唯一用途是承载 userId（权限每次请求现查库，不进 token）。
+ *
+ * <p>密钥来源环境变量 {@code JWT_SECRET}（须 ≥ 32 字节）；未配置或过短时启动期生成随机密钥并告警——
+ * 此时重启会让所有已签发 token 失效，生产环境必须配置固定密钥。
+ * ponytail: 不引入刷新 token / 黑名单，登出 = 前端清 token（JWT 无状态）。
+ */
+@Component
+@Slf4j
+public class JwtUtil {
+
+    private static final int MIN_SECRET_BYTES = 32;
+
+    private final SecretKey key;
+    private final long expirationMillis;
+
+    public JwtUtil(
+            @Value("${jwt.secret:}") String secret,
+            @Value("${jwt.expiration-hours:24}") long expirationHours) {
+        this.key = resolveKey(secret);
+        this.expirationMillis = expirationHours * 3600_000L;
+    }
+
+    /**
+     * 签发 token，subject 为 userId 字符串。
+     */
+    public String generate(Integer userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationMillis))
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * 解析 userId；token 非法/过期返回 null，由拦截器据此返回 401。
+     */
+    public Integer parseUserId(String token) {
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+        try {
+            String subject =
+                    Jwts.parser()
+                            .verifyWith(key)
+                            .build()
+                            .parseSignedClaims(token)
+                            .getPayload()
+                            .getSubject();
+            return Integer.valueOf(subject);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static SecretKey resolveKey(String secret) {
+        if (secret != null && secret.getBytes(StandardCharsets.UTF_8).length >= MIN_SECRET_BYTES) {
+            return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        }
+        log.warn(
+                "jwt.secret is missing or shorter than {} bytes; generating an in-memory random"
+                        + " key. All tokens will invalidate on restart. Configure JWT_SECRET for"
+                        + " production.",
+                MIN_SECRET_BYTES);
+        // ponytail: 直接用随机字节走 hmacShaKeyFor，避开 jjwt 0.12.x secretKeyFor 重载歧义。
+        byte[] randomBytes = new byte[MIN_SECRET_BYTES];
+        new SecureRandom().nextBytes(randomBytes);
+        return Keys.hmacShaKeyFor(randomBytes);
+    }
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/util/PasswordUtil.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/util/PasswordUtil.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.util;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+/**
+ * 密码哈希：JDK 标准库 PBKDF2WithHmacSHA256，零新依赖。
+ *
+ * <p>存储格式 {@code pbkdf2$<iter>$<base64Salt>$<base64Hash>}；迭代次数与盐长度固定，校验时从串中解析。
+ * OWASP 2023 推荐 PBKDF2-SHA256 迭代 ≥ 600000，此处取 210000（兼顾百人内网规模与登录耗时），
+ * ponytail: 如安全规范要求更高强度或换 Argon2，调迭代数或换算法即可，存储格式兼容。
+ */
+public final class PasswordUtil {
+
+    private static final String ALGORITHM = "PBKDF2WithHmacSHA256";
+    private static final int ITERATIONS = 210000;
+    private static final int SALT_BYTES = 16;
+    private static final int HASH_BITS = 256;
+    private static final String PREFIX = "pbkdf2";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private PasswordUtil() {}
+
+    /**
+     * 生成 {@code pbkdf2$iter$salt$hash} 串。
+     */
+    public static String hash(String password) {
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("Password must not be blank.");
+        }
+        byte[] salt = new byte[SALT_BYTES];
+        RANDOM.nextBytes(salt);
+        byte[] hash = derive(password, salt, ITERATIONS);
+        return PREFIX + "$" + ITERATIONS + "$" + base64(salt) + "$" + base64(hash);
+    }
+
+    /**
+     * 校验明文与已存储的哈希串是否匹配；存储串格式非法或为 null 一律返回 false。
+     */
+    public static boolean verify(String password, String stored) {
+        if (password == null || stored == null) {
+            return false;
+        }
+        String[] parts = stored.split("\\$");
+        if (parts.length != 4 || !PREFIX.equals(parts[0])) {
+            return false;
+        }
+        try {
+            int iterations = Integer.parseInt(parts[1]);
+            byte[] salt = Base64.getDecoder().decode(parts[2]);
+            byte[] expected = Base64.getDecoder().decode(parts[3]);
+            byte[] actual = derive(password, salt, iterations);
+            return constantTimeEquals(expected, actual);
+        } catch (IllegalArgumentException e) {
+            // NumberFormatException 是 IllegalArgumentException 子类，已一并覆盖。
+            return false;
+        }
+    }
+
+    private static byte[] derive(String password, byte[] salt, int iterations) {
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(ALGORITHM);
+            PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterations, HASH_BITS);
+            SecretKey key = factory.generateSecret(spec);
+            return key.getEncoded();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("PBKDF2WithHmacSHA256 unavailable", e);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to derive password hash", e);
+        }
+    }
+
+    private static String base64(byte[] bytes) {
+        return Base64.getEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static boolean constantTimeEquals(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        int diff = 0;
+        for (int i = 0; i < a.length; i++) {
+            diff |= a[i] ^ b[i];
+        }
+        return diff == 0;
+    }
+}

--- a/data-agent-backend/src/main/resources/mapper/SysUserMapper.xml
+++ b/data-agent-backend/src/main/resources/mapper/SysUserMapper.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.github.malonetalk.mapper.SysUserMapper">
+
+    <resultMap id="BaseResultMap" type="io.github.malonetalk.entity.SysUser">
+        <id column="id" property="id"/>
+        <result column="username" property="username"/>
+        <result column="password_hash" property="passwordHash"/>
+        <result column="display_name" property="displayName"/>
+        <result column="role_id" property="roleId"/>
+        <result column="idp_type" property="idpType"/>
+        <result column="idp_user_id" property="idpUserId"/>
+        <result column="status" property="status"/>
+        <result column="create_time" property="createTime"/>
+        <result column="update_time" property="updateTime"/>
+    </resultMap>
+
+    <resultMap id="AuthProjectionMap" type="io.github.malonetalk.common.UserContext">
+        <constructor>
+            <idArg column="id" javaType="java.lang.Integer"/>
+            <arg column="username" javaType="java.lang.String"/>
+            <arg column="display_name" javaType="java.lang.String"/>
+        </constructor>
+    </resultMap>
+
+    <select id="selectByUsername" resultMap="BaseResultMap">
+        SELECT * FROM sys_user
+        WHERE username = #{username} AND idp_type = 'LOCAL'
+    </select>
+
+    <select id="selectById" resultMap="BaseResultMap">
+        SELECT * FROM sys_user WHERE id = #{id}
+    </select>
+
+    <select id="selectAuthProjection" resultMap="AuthProjectionMap">
+        SELECT id, username, display_name FROM sys_user
+        WHERE id = #{id} AND status = 1
+    </select>
+
+    <insert id="insert" parameterType="io.github.malonetalk.entity.SysUser" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO sys_user (
+            username, password_hash, display_name, role_id, idp_type, idp_user_id, status,
+            create_time, update_time
+        ) VALUES (
+            #{username}, #{passwordHash}, #{displayName}, #{roleId}, #{idpType}, #{idpUserId}, #{status},
+            #{createTime}, #{updateTime}
+        )
+    </insert>
+
+    <update id="updatePassword">
+        UPDATE sys_user
+        SET password_hash = #{passwordHash}, update_time = #{updateTime}
+        WHERE id = #{id}
+    </update>
+
+    <select id="countAll" resultType="int">
+        SELECT COUNT(*) FROM sys_user
+    </select>
+
+</mapper>

--- a/data-agent-frontend/src/App.vue
+++ b/data-agent-frontend/src/App.vue
@@ -16,13 +16,19 @@
  -->
 
 <script setup lang="ts">
-  import { RouterView } from 'vue-router';
+  import { computed } from 'vue';
+  import { useRoute, RouterView } from 'vue-router';
   import AppHeader from './components/layout/AppHeader.vue';
   import AppSidebar from './components/layout/AppSidebar.vue';
+
+  const route = useRoute();
+  // 登录页全屏独立渲染，不挂顶栏/侧栏。
+  const isLoginPage = computed(() => route.path === '/login');
 </script>
 
 <template>
-  <div class="app-container">
+  <RouterView v-if="isLoginPage" />
+  <div v-else class="app-container">
     <AppHeader />
     <div class="app-main">
       <AppSidebar />

--- a/data-agent-frontend/src/api/agent.ts
+++ b/data-agent-frontend/src/api/agent.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { ApiError } from './request';
+import { ApiError, handleUnauthorized } from './request';
 
 export type ChatStreamEventType =
   | 'summary'
@@ -99,8 +99,21 @@ async function resolveApiError(response: Response, fallback: string): Promise<Ap
   }
 }
 
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('token');
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
 async function fetchJson<T>(url: string, fallback: string): Promise<T> {
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: authHeaders() });
+  if (response.status === 401) {
+    handleUnauthorized();
+    throw new ApiError('登录已过期，请重新登录', { code: 401 });
+  }
   if (!response.ok) {
     throw await resolveApiError(response, `${fallback}: ${response.status} ${response.statusText}`);
   }
@@ -132,10 +145,15 @@ export async function* streamChat(
 ): AsyncGenerator<ChatStreamEvent> {
   const response = await fetch('/api/agent/chat/stream', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
     body: JSON.stringify(request),
     signal: abortSignal,
   });
+
+  if (response.status === 401) {
+    handleUnauthorized();
+    throw new ApiError('登录已过期，请重新登录', { code: 401 });
+  }
 
   if (!response.ok) {
     throw await resolveApiError(

--- a/data-agent-frontend/src/api/auth.ts
+++ b/data-agent-frontend/src/api/auth.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+
+import request from './request';
+
+export interface UserInfoResponse {
+  userId: number;
+  username: string;
+  displayName: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: UserInfoResponse;
+}
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface ChangePasswordRequest {
+  oldPassword: string;
+  newPassword: string;
+}
+
+// 沿用项目约定：泛型为完整 ApiResponse 结构，调用处取 res.data.data。
+type ApiResult<T> = { code: number; message: string; data: T };
+
+export function login(payload: LoginRequest) {
+  return request.post<ApiResult<LoginResponse>>('/auth/login', payload).then(res => res.data.data);
+}
+
+export function fetchMe() {
+  return request.get<ApiResult<UserInfoResponse>>('/auth/me').then(res => res.data.data);
+}
+
+export function changePassword(payload: ChangePasswordRequest) {
+  return request
+    .post<ApiResult<boolean>>('/auth/change-password', payload)
+    .then(res => res.data.data);
+}

--- a/data-agent-frontend/src/api/request.ts
+++ b/data-agent-frontend/src/api/request.ts
@@ -58,12 +58,30 @@ const service: AxiosInstance = axios.create({
 
 service.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
+    // 直接读 localStorage 避免与 user store 循环依赖；store 写入时同步写 localStorage。
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     return config;
   },
   error => {
     return Promise.reject(error);
   },
 );
+
+function clearAuthAndRedirectLogin() {
+  localStorage.removeItem('token');
+  localStorage.removeItem('userInfo');
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login';
+  }
+}
+
+/** SSE/原生 fetch 链路复用：401 时清凭证并跳登录。 */
+export function handleUnauthorized() {
+  clearAuthAndRedirectLogin();
+}
 
 service.interceptors.response.use(
   (response: AxiosResponse<ApiResponse>) => {
@@ -76,6 +94,18 @@ service.interceptors.response.use(
     return response;
   },
   error => {
+    const status = error.response?.status;
+    // 401：token 缺失/过期/用户禁用。在登录页之外 → 清凭证跳登录；在登录页 → 显示后端文案（如"用户名或密码错误"）。
+    if (status === 401) {
+      const responseBody = error.response?.data as ApiResponse | undefined;
+      const apiError = toApiError(responseBody, '登录已过期，请重新登录');
+      if (window.location.pathname !== '/login') {
+        clearAuthAndRedirectLogin();
+      } else {
+        showApiError(apiError);
+      }
+      return Promise.reject(apiError);
+    }
     const responseBody = error.response?.data as ApiResponse | undefined;
     const apiError = toApiError(responseBody, error.message || '网络错误');
     showApiError(apiError);

--- a/data-agent-frontend/src/components/layout/AppHeader.vue
+++ b/data-agent-frontend/src/components/layout/AppHeader.vue
@@ -16,9 +16,18 @@
  -->
 
 <script setup lang="ts">
+  import { useRouter } from 'vue-router';
   import { useThemeStore } from '@/stores/theme';
+  import { useUserStore } from '@/stores/user';
 
   const themeStore = useThemeStore();
+  const userStore = useUserStore();
+  const router = useRouter();
+
+  function onLogout() {
+    userStore.logout();
+    router.push('/login');
+  }
 </script>
 
 <template>
@@ -37,6 +46,10 @@
         <span v-if="themeStore.mode === 'light'">🌙</span>
         <span v-else>☀️</span>
       </button>
+      <span v-if="userStore.userInfo" class="user-name">
+        {{ userStore.userInfo.displayName }}
+      </span>
+      <button class="logout-btn" title="登出" @click="onLogout">登出</button>
     </div>
   </header>
 </template>
@@ -97,6 +110,30 @@
   }
 
   .theme-toggle:hover {
+    background: var(--app-bg-hover);
+  }
+
+  .user-name {
+    font-size: 13px;
+    color: var(--app-text-secondary);
+    white-space: nowrap;
+  }
+
+  .logout-btn {
+    height: 32px;
+    padding: 0 12px;
+    border: 1px solid var(--app-border);
+    border-radius: 6px;
+    background: var(--app-bg-card);
+    color: var(--app-text-primary);
+    font-size: 13px;
+    cursor: pointer;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
+  }
+
+  .logout-btn:hover {
     background: var(--app-bg-hover);
   }
 </style>

--- a/data-agent-frontend/src/main.ts
+++ b/data-agent-frontend/src/main.ts
@@ -23,6 +23,7 @@ import zhCn from 'element-plus/es/locale/lang/zh-cn';
 import * as ElementPlusIconsVue from '@element-plus/icons-vue';
 import router from './router';
 import App from './App.vue';
+import { useUserStore } from './stores/user';
 import './styles/theme.css';
 import './styles/main.css';
 
@@ -32,7 +33,10 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
   app.component(key, component);
 }
 
-app.use(createPinia());
+const pinia = createPinia();
+app.use(pinia);
+// 启动时从 localStorage 恢复登录态（路由守卫据此决定是否放行）。
+useUserStore(pinia).restore();
 app.use(router);
 app.use(ElementPlus, { locale: zhCn });
 

--- a/data-agent-frontend/src/router/index.ts
+++ b/data-agent-frontend/src/router/index.ts
@@ -6,19 +6,27 @@
  * published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
  *
- * This program is distributed in the hope that it will be useful
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
  */
 
 import { createRouter, createWebHistory } from 'vue-router';
 import type { RouteRecordRaw } from 'vue-router';
+import { useUserStore } from '@/stores/user';
 
 const routes: RouteRecordRaw[] = [
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('@/views/login/LoginView.vue'),
+    meta: { title: '登录' },
+  },
   {
     path: '/',
     redirect: '/chat',
@@ -68,6 +76,15 @@ const router = createRouter({
 
 router.beforeEach((to, _from, next) => {
   document.title = `${to.meta.title || 'Data Agent'}`;
+  const userStore = useUserStore();
+  if (!userStore.isLoggedIn && to.path !== '/login') {
+    next('/login');
+    return;
+  }
+  if (userStore.isLoggedIn && to.path === '/login') {
+    next('/chat');
+    return;
+  }
   next();
 });
 

--- a/data-agent-frontend/src/stores/user.ts
+++ b/data-agent-frontend/src/stores/user.ts
@@ -6,55 +6,81 @@
  * published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
  *
- * This program is distributed in the hope that it will be useful
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
  */
 
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { login as loginApi, type LoginRequest, type UserInfoResponse } from '@/api/auth';
+
+const TOKEN_KEY = 'token';
+const USER_KEY = 'userInfo';
 
 export const useUserStore = defineStore('user', () => {
   const token = ref<string>('');
-  const userInfo = ref<{
-    id: string;
-    username: string;
-    nickname: string;
-    avatar?: string;
-  } | null>(null);
+  const userInfo = ref<UserInfoResponse | null>(null);
 
-  const setToken = (newToken: string) => {
+  const isLoggedIn = computed(() => Boolean(token.value));
+
+  function setToken(newToken: string) {
     token.value = newToken;
-    localStorage.setItem('token', newToken);
-  };
+    localStorage.setItem(TOKEN_KEY, newToken);
+  }
 
-  const setUserInfo = (info: typeof userInfo.value) => {
+  function setUserInfo(info: UserInfoResponse | null) {
     userInfo.value = info;
-  };
+    if (info) {
+      localStorage.setItem(USER_KEY, JSON.stringify(info));
+    } else {
+      localStorage.removeItem(USER_KEY);
+    }
+  }
 
-  const logout = () => {
+  async function login(payload: LoginRequest) {
+    const result = await loginApi(payload);
+    setToken(result.token);
+    setUserInfo(result.user);
+    return result;
+  }
+
+  function logout() {
     token.value = '';
     userInfo.value = null;
-    localStorage.removeItem('token');
-  };
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  }
 
-  const initToken = () => {
-    const savedToken = localStorage.getItem('token');
+  /** 启动时从 localStorage 恢复 token/用户信息（不校验有效性，401 时由请求层清空并跳登录）。 */
+  function restore() {
+    const savedToken = localStorage.getItem(TOKEN_KEY);
     if (savedToken) {
       token.value = savedToken;
     }
-  };
+    const savedUser = localStorage.getItem(USER_KEY);
+    if (savedUser) {
+      try {
+        userInfo.value = JSON.parse(savedUser) as UserInfoResponse;
+      } catch {
+        localStorage.removeItem(USER_KEY);
+      }
+    }
+  }
 
   return {
     token,
     userInfo,
+    isLoggedIn,
     setToken,
     setUserInfo,
+    login,
     logout,
-    initToken,
+    restore,
   };
 });

--- a/data-agent-frontend/src/views/login/LoginView.vue
+++ b/data-agent-frontend/src/views/login/LoginView.vue
@@ -1,0 +1,129 @@
+<!--
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ -->
+
+<script setup lang="ts">
+  import { reactive, ref } from 'vue';
+  import { useRouter } from 'vue-router';
+  import { ElMessage, type FormInstance, type FormRules } from 'element-plus';
+  import { useUserStore } from '@/stores/user';
+
+  const router = useRouter();
+  const userStore = useUserStore();
+
+  const formRef = ref<FormInstance>();
+  const loading = ref(false);
+  const form = reactive({ username: '', password: '' });
+
+  const rules: FormRules<typeof form> = {
+    username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
+    password: [{ required: true, message: '请输入密码', trigger: 'blur' }],
+  };
+
+  async function onSubmit() {
+    if (!formRef.value) return;
+    const valid = await formRef.value.validate().catch(() => false);
+    if (!valid) return;
+    loading.value = true;
+    try {
+      await userStore.login({ username: form.username, password: form.password });
+      ElMessage.success('登录成功');
+      router.push('/chat');
+    } catch {
+      // 401 已由请求层统一提示（"用户名或密码错误" 等），此处仅复位按钮。
+    } finally {
+      loading.value = false;
+    }
+  }
+</script>
+
+<template>
+  <div class="login-page">
+    <div class="login-card">
+      <div class="login-title">Data Agent</div>
+      <div class="login-subtitle">请登录后使用</div>
+      <el-form
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        size="large"
+        label-position="top"
+        @submit.prevent="onSubmit"
+      >
+        <el-form-item label="用户名" prop="username">
+          <el-input
+            v-model="form.username"
+            placeholder="请输入用户名"
+            autocomplete="username"
+            @keyup.enter="onSubmit"
+          />
+        </el-form-item>
+        <el-form-item label="密码" prop="password">
+          <el-input
+            v-model="form.password"
+            type="password"
+            show-password
+            placeholder="请输入密码"
+            autocomplete="current-password"
+            @keyup.enter="onSubmit"
+          />
+        </el-form-item>
+        <el-button type="primary" class="login-submit" :loading="loading" @click="onSubmit">
+          登录
+        </el-button>
+      </el-form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .login-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background-color: var(--app-bg-page);
+  }
+
+  .login-card {
+    width: 360px;
+    padding: 32px;
+    background-color: var(--app-bg-card);
+    border: 1px solid var(--app-border);
+    border-radius: 12px;
+    box-shadow: var(--app-shadow-lg);
+  }
+
+  .login-title {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--app-text-primary);
+    letter-spacing: -0.5px;
+  }
+
+  .login-subtitle {
+    margin-top: 4px;
+    margin-bottom: 24px;
+    font-size: 13px;
+    color: var(--app-text-secondary);
+  }
+
+  .login-submit {
+    width: 100%;
+    margin-top: 8px;
+  }
+</style>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,11 +20,11 @@ Data Agent 需要一张 MySQL 元数据库来存放语义层、数据源、会�
 # 创建数据库（字符集务必为 utf8mb4）
 mysql -u root -p -e "CREATE DATABASE data_agent CHARACTER SET utf8mb4;"
 
-# 导入表结构
-mysql -u root -p data_agent < sql/data_source.sql
+# 导入表结构（sql/ 目录下所有 .sql 文件均需执行）
+for f in sql/*.sql; do mysql -u root -p data_agent < "$f"; done
 ```
 
-> 脚本位于仓库 `sql/data_source.sql`，包含 `datasource`、`table_info`、`column` 语义层等表。
+> `sql/` 目录共三个脚本：`data_source.sql`（数据源与语义层表）、`metric.sql`（指标口径表）、`sys_user.sql`（用户表，登录功能依赖）。三者均需导入。
 
 ## 3. 配置并启动后端
 

--- a/sql/sys_user.sql
+++ b/sql/sys_user.sql
@@ -1,0 +1,18 @@
+-- 用户表（带身份源抽象：兼容本系统账号 / 钉钉 / 飞书 / 企业微信）
+CREATE TABLE IF NOT EXISTS `sys_user` (
+    `id`            INT NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+    `username`      VARCHAR(64)  NOT NULL COMMENT '登录名；外部身份源用户=身份源昵称（可重名，靠 uk_idp 区分）',
+    `password_hash` VARCHAR(255) NULL COMMENT 'PBKDF2 哈希，仅 LOCAL 身份源使用；外部身份源用户为空',
+    `display_name`  VARCHAR(64)  NOT NULL COMMENT '显示名',
+    `role_id`       INT NOT NULL DEFAULT 0 COMMENT '角色ID；0=未分配角色（无任何表权限）',
+    `idp_type`      VARCHAR(16)  NOT NULL DEFAULT 'LOCAL' COMMENT '身份源：LOCAL=本系统账号 / DINGTALK / FEISHU / WECOM',
+    `idp_user_id`   VARCHAR(64)  NULL COMMENT '身份源里的用户ID（LOCAL为空）',
+    `status`        TINYINT NOT NULL DEFAULT 1 COMMENT '1=启用 0=禁用',
+    `create_time`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_time`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    PRIMARY KEY (`id`),
+    KEY `idx_username` (`username`),
+    UNIQUE KEY `uk_idp` (`idp_type`, `idp_user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户';
+-- 说明：username 用普通索引而非唯一键——外部身份源昵称允许重名（身份靠 uk_idp 区分）；
+-- LOCAL 本地账号的用户名唯一性由应用层（AuthService 创建用户时）保证。


### PR DESCRIPTION
relate #25 

Add username/password login with stateless JWT (HS256) and a request interceptor gating /api/** (login excluded). Introduce SysUser entity/mapper/SQL, Pbkdf2 password hashing via the JDK stdlib (no new dep), AdminBootstrapRunner that creates the initial admin when sys_user is empty (fail-closed if ADMIN_INIT_PASSWORD is unset), and /api/auth/login|me|change-password endpoints. Add a frontend login page with token storage in the user store and header logout. No role or permission checks yet — the permission round follows.