### PR TITLE
fix: strip trailing semicolons from SQL before subquery wrapping

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/datasource/SqlExecutor.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/datasource/SqlExecutor.java
@@ -93,7 +93,7 @@ public class SqlExecutor {
 
         //  inject LIMIT if absent, to prevent full table scans
         if (!hasLimit(select)) {
-            return "SELECT * FROM (" + sql + ") AS _sandbox LIMIT " + MAX_ROWS;
+            return "SELECT * FROM (" + select + ") AS _sandbox LIMIT " + MAX_ROWS;
         }
         return sql;
     }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/datasource/SqlExecutor.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/datasource/SqlExecutor.java
@@ -93,7 +93,12 @@ public class SqlExecutor {
 
         //  inject LIMIT if absent, to prevent full table scans
         if (!hasLimit(select)) {
-            return "SELECT * FROM (" + select + ") AS _sandbox LIMIT " + MAX_ROWS;
+            // strip trailing semicolon to avoid syntax error in subquery
+            String safeSql = sql.trim();
+            if (safeSql.endsWith(";")) {
+                safeSql = safeSql.substring(0, safeSql.length() - 1).trim();
+            }
+            return "SELECT * FROM (" + safeSql + ") AS _sandbox LIMIT " + MAX_ROWS;
         }
         return sql;
     }


### PR DESCRIPTION
直接使用sql会导致运行报错，被包起来后存在分号，case：
<img width="1457" height="649" alt="image" src="https://github.com/user-attachments/assets/9e8de052-57e3-482c-b7c9-269431c3bb00" />