### PR TITLE
fix: resolve stream request canceled on first message after login

### DIFF
--- a/data-agent-frontend/src/views/chat/ChatView.vue
+++ b/data-agent-frontend/src/views/chat/ChatView.vue
@@ -138,7 +138,8 @@
   watch(
     () => route.params.sessionId,
     async newSid => {
-      if (newSid && typeof newSid === 'string') {
+      // Avoid triggering loadHistory when router.replace updates URL on first message
+      if (newSid && typeof newSid === 'string' && newSid !== sessionId.value) {
         await loadHistory(newSid);
         await resolveBoundDatasource(newSid);
       }


### PR DESCRIPTION
环境：
windows，进程里启动前后端。

问题复现：
用户第一次登陆之后的第一次对话，对话发送后，页面重新load。具体表现为stream接口返回报错。

<img width="1427" height="195" alt="2c016aa4951b34f4e73b252ec8ac7de0" src="https://github.com/user-attachments/assets/7eade765-9e35-48f1-b2ff-86c41ca52426" />
