### PR TITLE
feat(chat): add input history navigation and message copy

### DIFF
--- a/data-agent-frontend/src/views/chat/ChatView.vue
+++ b/data-agent-frontend/src/views/chat/ChatView.vue
@@ -55,6 +55,11 @@
   // 已发过消息 = 绑定已落库 = 不可再切换数据源（锁定语义）。
   const isBound = computed(() => messages.value.length > 0);
 
+  // 用户在当前会话中发过的消息文本（用于输入框上下键历史导航）
+  const userMessages = computed(() =>
+    messages.value.filter(m => m.role === 'user').map(m => m.content),
+  );
+
   // 未绑定的旧会话实际跟随全局激活源，展示其名字以免用户误以为可自由选源。
   const activeDatasourceName = computed(() => {
     if (datasourceId.value != null) return null;
@@ -247,8 +252,10 @@
       </div>
 
       <ChatInput
+        :key="sessionId"
         :is-streaming="isStreaming"
         :pending-question="pendingQuestion"
+        :user-messages="userMessages"
         @send="handleSend"
         @stop="stopStreaming"
       />

--- a/data-agent-frontend/src/views/chat/components/ChatInput.vue
+++ b/data-agent-frontend/src/views/chat/components/ChatInput.vue
@@ -16,13 +16,16 @@
  -->
 
 <script setup lang="ts">
-  import { ref, nextTick } from 'vue';
+  import { ref, computed, nextTick, watch } from 'vue';
 
   import type { PendingQuestion } from '@/composables/useAgentChat';
 
   const props = defineProps<{
     isStreaming: boolean;
     pendingQuestion: PendingQuestion | null;
+    // Previous user messages from the chat, used as input history for Up/Down navigation.
+    // Ordered oldest → newest.
+    userMessages: string[];
   }>();
 
   const emit = defineEmits<{
@@ -31,21 +34,57 @@
   }>();
 
   const inputText = ref('');
-  const textareaRef = ref<{ style: { height: string }; scrollHeight: number }>();
+  const textareaRef = ref<{
+    value: string;
+    style: { height: string };
+    scrollHeight: number;
+    selectionStart: number;
+    selectionEnd: number;
+  }>();
+
+  // -1 = not browsing; 0 = newest user message, increasing = older
+  const historyIndex = ref(-1);
+
+  // Full original message at the current history position (used by Tab confirmation)
+  const historyFull = computed(() => {
+    if (historyIndex.value < 0) return '';
+    const msgs = props.userMessages;
+    const idx = msgs.length - 1 - historyIndex.value;
+    return idx >= 0 && idx < msgs.length ? msgs[idx] : '';
+  });
+
+  // Truncated version shown as placeholder: max 20 chars or cut at first newline,
+  // whichever comes first. Appends "…" whenever anything was dropped.
+  const historyPreview = computed(() => {
+    const raw = historyFull.value;
+    if (!raw) return null;
+    const nl = raw.indexOf('\n');
+    const cut = nl === -1 ? raw.length : nl;
+    const limit = Math.min(50, cut);
+    const truncated = raw.slice(0, limit);
+    return truncated.length < raw.length ? truncated + '…' : truncated;
+  });
+
+  watch(inputText, () => {
+    nextTick(autoResize);
+  });
 
   function handleSend() {
     const text = inputText.value.trim();
     if (!text || props.isStreaming) return;
+    historyIndex.value = -1;
     emit('send', text);
     inputText.value = '';
-    nextTick(() => {
-      if (textareaRef.value) {
-        textareaRef.value.style.height = 'auto';
-      }
-    });
   }
 
-  function handleKeydown(e: { key: string; shiftKey: boolean; preventDefault: () => void }) {
+  function handleKeydown(e: {
+    key: string;
+    shiftKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    metaKey: boolean;
+    preventDefault: () => void;
+  }) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (props.isStreaming) {
@@ -53,6 +92,55 @@
       } else {
         handleSend();
       }
+      return;
+    }
+
+    const hasModifier = e.shiftKey || e.ctrlKey || e.altKey || e.metaKey;
+    if (hasModifier) return;
+
+    const el = textareaRef.value;
+    if (!el) return;
+
+    // History preview via Up/Down:
+    // - When input is empty → always works
+    // - When input has text → only when cursor is at the boundary
+    //   (Up at start of text, Down at end of text)
+    // The history item shows as placeholder (not real value); Tab to confirm.
+
+    if (e.key === 'ArrowUp') {
+      if (props.userMessages.length === 0) return;
+      const len = el.value.length;
+      const cursorAtStart = el.selectionStart === 0 && el.selectionEnd === 0;
+      if (len > 0 && !cursorAtStart) return;
+      e.preventDefault();
+      const next = historyIndex.value === -1 ? 0 : historyIndex.value + 1;
+      historyIndex.value = Math.min(next, props.userMessages.length - 1);
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      if (historyIndex.value === -1) return;
+      const len = el.value.length;
+      const cursorAtEnd = el.selectionStart === len && el.selectionEnd === len;
+      if (len > 0 && !cursorAtEnd) return;
+      e.preventDefault();
+      historyIndex.value = Math.max(historyIndex.value - 1, -1);
+      return;
+    }
+
+    // Tab: confirm the current history preview, filling the full original text into the input
+    if (e.key === 'Tab' && historyPreview.value !== null) {
+      e.preventDefault();
+      inputText.value = historyFull.value;
+      historyIndex.value = -1;
+      nextTick(autoResize);
+      return;
+    }
+
+    // Escape: dismiss the history preview
+    if (e.key === 'Escape' && historyPreview.value !== null) {
+      e.preventDefault();
+      historyIndex.value = -1;
     }
   }
 
@@ -75,15 +163,16 @@
       v-model="inputText"
       class="chat-input__textarea"
       :placeholder="
-        props.pendingQuestion && !isStreaming
-          ? '输入你的回答，Enter 发送...'
-          : isStreaming
-            ? '正在回复中...'
-            : '输入消息，Enter 发送，Shift+Enter 换行'
+        historyPreview !== null
+          ? historyPreview + '  (Tab 确认)'
+          : props.pendingQuestion && !isStreaming
+            ? '输入你的回答，Enter 发送...'
+            : isStreaming
+              ? '正在回复中...'
+              : '输入消息，Enter 发送，Shift+Enter 换行'
       "
       :disabled="isStreaming"
       rows="1"
-      @input="autoResize"
       @keydown="handleKeydown"
     />
     <el-button

--- a/data-agent-frontend/src/views/chat/components/ChatMessage.vue
+++ b/data-agent-frontend/src/views/chat/components/ChatMessage.vue
@@ -16,7 +16,7 @@
  -->
 
 <script setup lang="ts">
-  import { computed, ref } from 'vue';
+  import { computed, ref, onUnmounted } from 'vue';
   import { marked } from 'marked';
   import type { ChatMessage as ChatMessageType } from '@/composables/useAgentChat';
   import TracePanel from './TracePanel.vue';
@@ -49,7 +49,6 @@
 
   const copied = ref(false);
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
-
   async function copyMessage() {
     try {
       await navigator.clipboard.writeText(props.message.content);
@@ -62,6 +61,10 @@
       // Clipboard API may fail in insecure contexts; ignore.
     }
   }
+
+  onUnmounted(() => {
+    if (resetTimer) clearTimeout(resetTimer);
+  });
 </script>
 
 <template>

--- a/data-agent-frontend/src/views/chat/components/ChatMessage.vue
+++ b/data-agent-frontend/src/views/chat/components/ChatMessage.vue
@@ -16,7 +16,7 @@
  -->
 
 <script setup lang="ts">
-  import { computed } from 'vue';
+  import { computed, ref } from 'vue';
   import { marked } from 'marked';
   import type { ChatMessage as ChatMessageType } from '@/composables/useAgentChat';
   import TracePanel from './TracePanel.vue';
@@ -46,10 +46,39 @@
 
   const renderedText = computed(() => marked.parse(contentParts.value.text) as string);
   const renderedSummary = computed(() => marked.parse(contentParts.value.summary) as string);
+
+  const copied = ref(false);
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copyMessage() {
+    try {
+      await navigator.clipboard.writeText(props.message.content);
+      copied.value = true;
+      if (resetTimer) clearTimeout(resetTimer);
+      resetTimer = setTimeout(() => {
+        copied.value = false;
+      }, 2000);
+    } catch {
+      // Clipboard API may fail in insecure contexts; ignore.
+    }
+  }
 </script>
 
 <template>
   <div class="chat-message" :class="`chat-message--${message.role}`">
+    <div v-if="message.role === 'user'" class="chat-message__actions">
+      <button
+        type="button"
+        class="chat-message__copy-btn"
+        title="复制"
+        @click.stop="copyMessage"
+      >
+        <el-icon :size="16">
+          <Check v-if="copied" />
+          <CopyDocument v-else />
+        </el-icon>
+      </button>
+    </div>
     <div class="chat-message__bubble">
       <TracePanel
         v-if="message.role === 'agent'"
@@ -88,6 +117,7 @@
 
   .chat-message--user {
     justify-content: flex-end;
+    align-items: center;
   }
 
   .chat-message--agent {
@@ -255,6 +285,42 @@
   .chat-message--user .chat-message__cursor {
     color: var(--app-accent-text);
     opacity: 0.7;
+  }
+
+  .chat-message__actions {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding-right: 8px;
+  }
+
+  .chat-message__copy-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--app-text-secondary);
+    opacity: 0;
+    cursor: pointer;
+    transition:
+      opacity 0.15s,
+      background-color 0.15s,
+      color 0.15s;
+  }
+
+  .chat-message--user:hover .chat-message__copy-btn {
+    opacity: 0.6;
+  }
+
+  .chat-message__copy-btn:hover {
+    opacity: 1 !important;
+    color: var(--app-text-primary);
+    background: var(--app-bg-hover);
   }
 
   @keyframes blink {

--- a/data-agent-frontend/src/views/chat/components/ChatMessage.vue
+++ b/data-agent-frontend/src/views/chat/components/ChatMessage.vue
@@ -67,12 +67,7 @@
 <template>
   <div class="chat-message" :class="`chat-message--${message.role}`">
     <div v-if="message.role === 'user'" class="chat-message__actions">
-      <button
-        type="button"
-        class="chat-message__copy-btn"
-        title="复制"
-        @click.stop="copyMessage"
-      >
+      <button type="button" class="chat-message__copy-btn" title="复制" @click.stop="copyMessage">
         <el-icon :size="16">
           <Check v-if="copied" />
           <CopyDocument v-else />


### PR DESCRIPTION
#51 

1、新增复制按钮
<img width="231" height="114" alt="image" src="https://github.com/user-attachments/assets/419c40ce-413f-42c6-847c-367a63622b93" />
<img width="291" height="119" alt="image" src="https://github.com/user-attachments/assets/e4122d9c-d2ce-4dc1-ab3b-a9e03c72f5f0" />

2、上下切换历史对话，如果换行 or 大于50字 则在placeholder中进行省略号截断。
<img width="369" height="78" alt="image" src="https://github.com/user-attachments/assets/d16a955f-3588-45ba-875c-d824dd739c5b" />
