### PR TITLE
feat(auth): isolate chat sessions per user with ownership checks

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/AgentService.java
@@ -79,24 +79,29 @@ public class AgentService {
     }
 
     public Flux<ChatStreamEvent> chatStream(
+            int userId,
             String sessionId,
             String userInput,
             List<ChatRequest.ToolResultInput> toolResults,
             Integer datasourceId) {
-        return Flux.defer(() -> streamAgent(sessionId, userInput, toolResults, datasourceId))
+        return Flux.defer(
+                        () -> streamAgent(userId, sessionId, userInput, toolResults, datasourceId))
                 .onErrorResume(this::toErrorEvent);
     }
 
     private Flux<ChatStreamEvent> streamAgent(
+            int userId,
             String sessionId,
             String userInput,
             List<ChatRequest.ToolResultInput> toolResults,
             Integer datasourceId) {
+        // 首次访问声明归属；已绑定会被 INSERT IGNORE 忽略
+        sessionService.bindUserSession(userId, sessionId);
         if (datasourceId != null) {
-            // 首次绑定；已绑定会被 INSERT IGNORE 忽略，锁定语义在 mapper 层保证。
             datasourceService.bindSessionDatasource(sessionId, datasourceId);
         }
-        ReActAgent agent = createAgent(ToolCallContext.builder().sessionId(sessionId).build());
+        ReActAgent agent =
+                createAgent(ToolCallContext.builder().sessionId(sessionId).userId(userId).build());
 
         Session session = sessionService.getOrCreateSession(sessionId);
         agent.loadIfExists(session, sessionId);

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/SessionService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/SessionService.java
@@ -28,19 +28,23 @@ import io.agentscope.core.session.Session;
 import io.agentscope.core.session.mysql.MysqlSession;
 import io.agentscope.core.state.SessionKey;
 import io.agentscope.core.state.SimpleSessionKey;
+import io.github.malonetalk.common.ErrorCode;
 import io.github.malonetalk.convertor.handler.ToolResultHandler;
 import io.github.malonetalk.dto.ChatStreamEvent;
 import io.github.malonetalk.dto.SessionDatasourceBinding;
 import io.github.malonetalk.dto.SessionInfo;
 import io.github.malonetalk.dto.TurnItem;
 import io.github.malonetalk.enums.ChatStreamEventType;
+import io.github.malonetalk.exception.BusinessException;
 import io.github.malonetalk.mapper.SessionDatasourceMapper;
+import io.github.malonetalk.mapper.UserSessionMapper;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,11 +61,16 @@ public class SessionService {
 
     private final DataSource dataSource;
     private final SessionDatasourceMapper sessionDatasourceMapper;
+    private final UserSessionMapper userSessionMapper;
     private final Map<String, Session> sessionCache = new ConcurrentHashMap<>();
 
-    public SessionService(DataSource dataSource, SessionDatasourceMapper sessionDatasourceMapper) {
+    public SessionService(
+            DataSource dataSource,
+            SessionDatasourceMapper sessionDatasourceMapper,
+            UserSessionMapper userSessionMapper) {
         this.dataSource = dataSource;
         this.sessionDatasourceMapper = sessionDatasourceMapper;
+        this.userSessionMapper = userSessionMapper;
     }
 
     public Session getOrCreateSession(String sessionId) {
@@ -72,7 +81,32 @@ public class SessionService {
         return new MysqlSession(dataSource, "data_agent", "agentscope_sessions", false);
     }
 
-    public List<Msg> getSessionDebug(String sessionId) {
+    /** 声明会话归属（INSERT IGNORE），首次访问时由 chatStream 调用。 */
+    public void bindUserSession(int userId, String sessionId) {
+        userSessionMapper.insertIgnore(userId, sessionId);
+    }
+
+    private void checkOwnership(int userId, String sessionId) {
+        if (!userSessionMapper.exists(userId, sessionId)) {
+            throw BusinessException.of(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+
+    public List<Msg> getSessionDebug(String sessionId, Integer userId) {
+        if (userId != null) {
+            checkOwnership(userId, sessionId);
+        }
+        return loadMessages(sessionId);
+    }
+
+    public List<TurnItem> getSessionHistory(String sessionId, Integer userId) {
+        if (userId != null) {
+            checkOwnership(userId, sessionId);
+        }
+        return buildTurnItems(loadMessages(sessionId));
+    }
+
+    private List<Msg> loadMessages(String sessionId) {
         Session session = getOrCreateSession(sessionId);
         if (!session.exists(SimpleSessionKey.of(sessionId))) {
             return Collections.emptyList();
@@ -80,16 +114,7 @@ public class SessionService {
         return session.getList(SimpleSessionKey.of(sessionId), "memory_messages", Msg.class);
     }
 
-    public List<TurnItem> getSessionHistory(String sessionId) {
-        Session session = getOrCreateSession(sessionId);
-
-        if (!session.exists(SimpleSessionKey.of(sessionId))) {
-            return Collections.emptyList();
-        }
-
-        List<Msg> messages =
-                session.getList(SimpleSessionKey.of(sessionId), "memory_messages", Msg.class);
-
+    private List<TurnItem> buildTurnItems(List<Msg> messages) {
         List<TurnItem> turns = new ArrayList<>();
         List<ContentBlock> agentBlocks = null;
 
@@ -192,32 +217,71 @@ public class SessionService {
                 .build();
     }
 
-    // TODO 2026/08/11 这里保留agentscope 的 MysqlSession.delete() ，虽然大概率不走 Spring 事务，
-    //  但注解至少明确了这是跨表操作的语义边界，后续如果有人接手知道这里需要考虑事务一致性。后期有时间回来完善这里的双表操作的事务
     @Transactional
-    public void clearSession(String sessionId) {
+    public void clearSession(String sessionId, Integer userId) {
+        if (userId != null) {
+            checkOwnership(userId, sessionId);
+        }
+        doClearSession(sessionId);
+    }
+
+    private void doClearSession(String sessionId) {
         Session session = sessionCache.remove(sessionId);
         if (session == null) {
             session = createMysqlSession();
         }
         session.delete(SimpleSessionKey.of(sessionId));
         sessionDatasourceMapper.deleteBySessionId(sessionId);
+        userSessionMapper.deleteBySessionId(sessionId);
     }
 
+    /**
+     * 清空全部会话：admin 清全量，普通用户清自己名下。
+     *
+     * @param userId null 表示 admin（清全量），非 null 表示指定用户
+     */
     @Transactional
-    public void clearAllSessions() {
-        Set<String> sessionIds = Set.copyOf(sessionCache.keySet());
-        for (String sessionId : sessionIds) {
-            clearSession(sessionId);
+    public void clearAllSessions(Integer userId) {
+        if (userId == null) {
+            // admin: clear everything — query db for session IDs, not local cache
+            MysqlSession session = createMysqlSession();
+            Set<SessionKey> keys = session.listSessionKeys();
+            if (keys != null) {
+                for (SessionKey key : keys) {
+                    doClearSession(key.toIdentifier());
+                }
+            }
+            return;
         }
+
+        List<String> userSessionIds = userSessionMapper.selectSessionIdsByUserId(userId);
+        for (String sessionId : userSessionIds) {
+            sessionCache.remove(sessionId);
+            MysqlSession session = createMysqlSession();
+            session.delete(SimpleSessionKey.of(sessionId));
+            sessionDatasourceMapper.deleteBySessionId(sessionId);
+        }
+        userSessionMapper.deleteByUserId(userId);
     }
 
-    public List<SessionInfo> listSessions() {
+    /**
+     * 列出会话列表。
+     *
+     * @param userId null 表示 admin（全量），非 null 表示只查该用户的会话
+     */
+    public List<SessionInfo> listSessions(Integer userId) {
         MysqlSession session = createMysqlSession();
         Set<SessionKey> keys = session.listSessionKeys();
 
         if (keys == null || keys.isEmpty()) {
             return Collections.emptyList();
+        }
+
+        Set<String> visibleIds;
+        if (userId == null) {
+            visibleIds = keys.stream().map(SessionKey::toIdentifier).collect(Collectors.toSet());
+        } else {
+            visibleIds = new HashSet<>(userSessionMapper.selectSessionIdsByUserId(userId));
         }
 
         Map<String, String[]> timestamps = new HashMap<>();
@@ -250,6 +314,9 @@ public class SessionService {
         List<SessionInfo> result = new ArrayList<>();
         for (SessionKey key : keys) {
             String sid = key.toIdentifier();
+            if (!visibleIds.contains(sid)) {
+                continue;
+            }
             List<Msg> messages = session.getList(key, "memory_messages", Msg.class);
 
             String title = "";

--- a/data-agent-backend/src/main/java/io/github/malonetalk/common/Constants.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/common/Constants.java
@@ -22,9 +22,12 @@ public final class Constants {
     public static final String SORT_ORDER_ASC = "asc";
     public static final String SORT_ORDER_DESC = "desc";
 
+    /** 管理员角色 id：AuthInterceptor 靠 role_id==1 判 @AdminOnly，删掉即永久锁死管理员。 */
+    public static final int ADMIN_ROLE_ID = 1;
+
+    public static final String PROPERTIES_PREFIX = "io.github.malonetalk";
+
     private Constants() {
         throw new IllegalCallerException("No Constants Instance for You!");
     }
-
-    public static final String PROPERTIES_PREFIX = "io.github.malonetalk";
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/controller/AgentController.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/controller/AgentController.java
@@ -17,14 +17,19 @@
  */
 package io.github.malonetalk.controller;
 
+import static io.github.malonetalk.common.Constants.ADMIN_ROLE_ID;
+
 import io.agentscope.core.message.Msg;
 import io.github.malonetalk.agent.AgentService;
 import io.github.malonetalk.agent.SessionService;
+import io.github.malonetalk.common.ErrorCode;
 import io.github.malonetalk.common.Result;
+import io.github.malonetalk.common.UserContext;
 import io.github.malonetalk.dto.ChatRequest;
 import io.github.malonetalk.dto.ChatStreamEvent;
 import io.github.malonetalk.dto.SessionInfo;
 import io.github.malonetalk.dto.TurnItem;
+import io.github.malonetalk.exception.BusinessException;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -52,9 +57,12 @@ public class AgentController {
     @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<ChatStreamEvent>> chatStream(
             @Valid @RequestBody ChatRequest request) {
-        log.info("SSE chat stream started: sessionId={}", request.sessionId());
+        // 在 servlet 线程抓 userId，避免 Reactor 线程拿不到 ThreadLocal
+        int userId = UserContext.require().userId();
+        log.info("SSE chat stream started: sessionId={}, userId={}", request.sessionId(), userId);
         return agentService
                 .chatStream(
+                        userId,
                         request.sessionId(),
                         request.message(),
                         request.toolResults(),
@@ -69,31 +77,52 @@ public class AgentController {
 
     @GetMapping("/session/{sessionId}/debug")
     public Result<List<Msg>> getSessionDebug(@PathVariable String sessionId) {
-        List<Msg> messages = sessionService.getSessionDebug(sessionId);
+        Integer userId = resolveUserId();
+        List<Msg> messages = sessionService.getSessionDebug(sessionId, userId);
         return Result.success(messages);
     }
 
     @GetMapping("/session/{sessionId}/history")
     public Result<List<TurnItem>> getSessionHistory(@PathVariable String sessionId) {
-        List<TurnItem> history = sessionService.getSessionHistory(sessionId);
+        Integer userId = resolveUserId();
+        List<TurnItem> history = sessionService.getSessionHistory(sessionId, userId);
         return Result.success(history);
     }
 
     @DeleteMapping("/session/{sessionId}")
     public Result<Boolean> clearSession(@PathVariable String sessionId) {
-        sessionService.clearSession(sessionId);
+        Integer userId = resolveUserId();
+        sessionService.clearSession(sessionId, userId);
         return Result.success(true);
     }
 
     @GetMapping("/sessions")
     public Result<List<SessionInfo>> listSessions() {
-        List<SessionInfo> sessions = sessionService.listSessions();
+        Integer userId = resolveUserId();
+        List<SessionInfo> sessions = sessionService.listSessions(userId);
         return Result.success(sessions);
     }
 
     @DeleteMapping("/session")
     public Result<Boolean> clearAllSessions() {
-        sessionService.clearAllSessions();
+        UserContext user = UserContext.require();
+        if (user.roleId() == null || user.roleId() != ADMIN_ROLE_ID) {
+            throw BusinessException.of(ErrorCode.FORBIDDEN);
+        }
+        sessionService.clearAllSessions(null);
         return Result.success(true);
+    }
+
+    /**
+     * 解析当前用户的 userId：admin 返回 null（不过滤），普通用户返回 userId。
+     *
+     * <p>admin (role_id=1) 能看到所有 session 且跳过所有权检查。
+     */
+    private static Integer resolveUserId() {
+        UserContext user = UserContext.require();
+        if (user.roleId() != null && user.roleId() == ADMIN_ROLE_ID) {
+            return null;
+        }
+        return user.userId();
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/entity/UserSession.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/entity/UserSession.java
@@ -15,9 +15,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * limitations under the License.
  */
-package io.github.malonetalk.agent;
+package io.github.malonetalk.entity;
 
-import lombok.Builder;
+import java.time.LocalDateTime;
+import lombok.Data;
 
-@Builder
-public record ToolCallContext(String sessionId, Integer userId) {}
+/** 用户-会话归属映射。 */
+@Data
+public class UserSession {
+
+    private Integer userId;
+    private String sessionId;
+    private LocalDateTime createTime;
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/interceptor/AuthInterceptor.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/interceptor/AuthInterceptor.java
@@ -17,6 +17,8 @@
  */
 package io.github.malonetalk.interceptor;
 
+import static io.github.malonetalk.common.Constants.ADMIN_ROLE_ID;
+
 import io.github.malonetalk.annotation.AdminOnly;
 import io.github.malonetalk.common.ErrorCode;
 import io.github.malonetalk.common.UserContext;
@@ -43,8 +45,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 @AllArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
-
-    private static final int ADMIN_ROLE_ID = 1;
 
     private final JwtUtil jwtUtil;
     private final SysUserMapper sysUserMapper;

--- a/data-agent-backend/src/main/java/io/github/malonetalk/mapper/UserSessionMapper.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/mapper/UserSessionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface UserSessionMapper {
+
+    /** 首次访问声明归属；主键冲突静默忽略。 */
+    int insertIgnore(@Param("userId") int userId, @Param("sessionId") String sessionId);
+
+    /** 查询指定用户是否拥有该会话，用于归属校验。 */
+    boolean exists(@Param("userId") int userId, @Param("sessionId") String sessionId);
+
+    /** 查询用户的所有会话 ID，用于 listSessions 过滤。 */
+    List<String> selectSessionIdsByUserId(@Param("userId") int userId);
+
+    /** 删除指定会话的归属记录。 */
+    int deleteBySessionId(@Param("sessionId") String sessionId);
+
+    /** 删除用户的所有归属记录。 */
+    int deleteByUserId(@Param("userId") int userId);
+}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/service/SysRoleServiceImpl.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/service/SysRoleServiceImpl.java
@@ -17,6 +17,8 @@
  */
 package io.github.malonetalk.service;
 
+import static io.github.malonetalk.common.Constants.ADMIN_ROLE_ID;
+
 import io.github.malonetalk.common.ErrorCode;
 import io.github.malonetalk.convertor.RoleConverter;
 import io.github.malonetalk.dto.ColumnPermissionResponse;
@@ -47,9 +49,6 @@ public class SysRoleServiceImpl implements SysRoleService {
     private final RoleTablePermissionMapper roleTablePermissionMapper;
     private final RoleHiddenColumnMapper roleHiddenColumnMapper;
     private final RoleConverter roleConverter;
-
-    /** 管理员角色 id：AuthInterceptor 靠 role_id==1 判 @AdminOnly，删掉即永久锁死管理员。 */
-    private static final int ADMIN_ROLE_ID = 1;
 
     @Override
     public List<RoleResponse> listAll() {

--- a/data-agent-backend/src/main/resources/application.properties
+++ b/data-agent-backend/src/main/resources/application.properties
@@ -21,11 +21,11 @@ mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
 
 # Model Configuration
-io.github.malonetalk.model.provider=dashscope
-io.github.malonetalk.model.name=qwen3-max
-io.github.malonetalk.model.base-url=
+io.github.malonetalk.model.provider=openai
+io.github.malonetalk.model.name=deepseek-v4-flash
+io.github.malonetalk.model.base-url=https://api.deepseek.com
 io.github.malonetalk.model.api-key=${IO_GITHUB_MALONETALK_MODEL_API_KEY:}
-io.github.malonetalk.model.thinking-enabled=${IO_GITHUB_MALONETALK_MODEL_THINKING_ENABLED:false}
+io.github.malonetalk.model.thinking-enabled=${IO_GITHUB_MALONETALK_MODEL_THINKING_ENABLED:true}
 
 spring.config.import=classpath:skill.properties
 

--- a/data-agent-backend/src/main/resources/mapper/UserSessionMapper.xml
+++ b/data-agent-backend/src/main/resources/mapper/UserSessionMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.github.malonetalk.mapper.UserSessionMapper">
+
+    <insert id="insertIgnore">
+        INSERT IGNORE INTO user_session (user_id, session_id)
+        VALUES (#{userId}, #{sessionId})
+    </insert>
+
+    <select id="exists" resultType="boolean">
+        SELECT COUNT(1) > 0
+        FROM user_session
+        WHERE user_id = #{userId} AND session_id = #{sessionId}
+    </select>
+
+    <select id="selectSessionIdsByUserId" resultType="string">
+        SELECT session_id FROM user_session WHERE user_id = #{userId}
+    </select>
+
+    <delete id="deleteBySessionId">
+        DELETE FROM user_session WHERE session_id = #{sessionId}
+    </delete>
+
+    <delete id="deleteByUserId">
+        DELETE FROM user_session WHERE user_id = #{userId}
+    </delete>
+
+</mapper>

--- a/sql/user_session.sql
+++ b/sql/user_session.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `user_session` (
+    `user_id`    INT          NOT NULL COMMENT '用户ID，关联 sys_user.id',
+    `session_id` VARCHAR(255) NOT NULL COMMENT '会话ID（对应 agentscope_sessions.session_id）',
+    `create_time` DATETIME    DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`user_id`, `session_id`),
+    KEY `idx_session_id` (`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户-会话归属表';


### PR DESCRIPTION
relate #104

- Add user_session ownership table; first visitor claims a session via INSERT IGNORE. History/debug/clear now verify ownership (non-owner → 404, existence not leaked). Session listing filters by user, and clearAllSessions is admin-only (403 otherwise); admin (role_id=1) bypasses via resolveUserId() returning null.

- userId is threaded from the servlet thread through chatStream into ToolCallContext so Reactor threads never read ThreadLocal. ADMIN_ROLE_ID is centralized into Constants. Model config switches to deepseek-v4-flash