### PR TITLE
fix: refine semantic metadata display and agent prompt data

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetDomainsTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetDomainsTool.java
@@ -35,12 +35,14 @@ public class GetDomainsTool implements MarkAgentTool {
     @Tool(
             name = "get_domains",
             description =
-                    "Get available data domains in the datasource. Call this tool first to discover"
-                            + " what domains are available before querying tables.")
+                    "Get available data domains, including domain names and descriptions. Call"
+                            + " this tool first to choose the most relevant domains before querying"
+                            + " tables.")
     public ToolResultBlock getDomains() {
         return toolExceptionMapper.run(
                 () ->
                         ToolResultBlock.text(
-                                JsonUtils.getJsonCodec().toJson(domainService.listDomainNames())));
+                                JsonUtils.getJsonCodec()
+                                        .toJson(domainService.listDomainPrompts())));
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/convertor/PromptConverter.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/convertor/PromptConverter.java
@@ -40,10 +40,7 @@ public final class PromptConverter {
                 .name(column.getColumnName())
                 .type(SemanticUtils.trimToNull(column.getTypeName()))
                 .primaryKey(column.getPrimaryKey())
-                .description(
-                        SemanticUtils.firstNonBlank(
-                                column.getColumnDescription(),
-                                column.getPhysicalColumnDescription()))
+                .description(SemanticUtils.trimToNull(column.getColumnDescription()))
                 .indexInfo(SemanticUtils.trimToNull(column.getIndexInfo()))
                 .build();
     }
@@ -56,9 +53,7 @@ public final class PromptConverter {
         return TablePromptResponse.builder()
                 .name(table.getTableName())
                 .domain(SemanticUtils.normalizeDomain(table.getDomain()))
-                .description(
-                        SemanticUtils.firstNonBlank(
-                                table.getTableDescription(), table.getPhysicalTableDescription()))
+                .description(SemanticUtils.trimToNull(table.getTableDescription()))
                 .relations(resolvedRelations)
                 .build();
     }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/DomainUpdateRequest.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/DomainUpdateRequest.java
@@ -20,4 +20,5 @@ package io.github.malonetalk.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record DomainUpdateRequest(
-        @NotBlank(message = "领域名称不能为空") String name, String description) {}
+        @NotBlank(message = "领域名称不能为空") String name,
+        @NotBlank(message = "域描述不能为空") String description) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/dto/prompt/DomainPromptResponse.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/dto/prompt/DomainPromptResponse.java
@@ -15,10 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * limitations under the License.
  */
-package io.github.malonetalk.dto;
+package io.github.malonetalk.dto.prompt;
 
-import jakarta.validation.constraints.NotBlank;
-
-public record DomainCreateRequest(
-        @NotBlank(message = "领域名称不能为空") String name,
-        @NotBlank(message = "域描述不能为空") String description) {}
+/** Agent-facing DTO for domain selection. */
+public record DomainPromptResponse(String name, String description) {}

--- a/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/DomainService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/DomainService.java
@@ -21,6 +21,7 @@ import io.github.malonetalk.dto.DomainCreateRequest;
 import io.github.malonetalk.dto.DomainPageQuery;
 import io.github.malonetalk.dto.DomainUpdateRequest;
 import io.github.malonetalk.dto.pagination.PageResponse;
+import io.github.malonetalk.dto.prompt.DomainPromptResponse;
 import io.github.malonetalk.entity.DomainInfo;
 import java.util.List;
 
@@ -37,4 +38,6 @@ public interface DomainService {
     void delete(Integer id);
 
     List<String> listDomainNames();
+
+    List<DomainPromptResponse> listDomainPrompts();
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/DomainServiceImpl.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/DomainServiceImpl.java
@@ -25,6 +25,7 @@ import io.github.malonetalk.dto.DomainCreateRequest;
 import io.github.malonetalk.dto.DomainPageQuery;
 import io.github.malonetalk.dto.DomainUpdateRequest;
 import io.github.malonetalk.dto.pagination.PageResponse;
+import io.github.malonetalk.dto.prompt.DomainPromptResponse;
 import io.github.malonetalk.entity.DomainInfo;
 import io.github.malonetalk.exception.BusinessException;
 import io.github.malonetalk.mapper.DomainInfoMapper;
@@ -139,6 +140,17 @@ public class DomainServiceImpl implements DomainService {
                 .map(DomainInfo::getName)
                 .distinct()
                 .sorted(String::compareToIgnoreCase)
+                .toList();
+    }
+
+    @Override
+    public List<DomainPromptResponse> listDomainPrompts() {
+        return domainInfoMapper.selectAll().stream()
+                .map(
+                        domain ->
+                                new DomainPromptResponse(
+                                        domain.getName(),
+                                        SemanticUtils.trimToNull(domain.getDescription())))
                 .toList();
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/sync/SemanticSyncApplyService.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/service/semantic/sync/SemanticSyncApplyService.java
@@ -354,6 +354,7 @@ public class SemanticSyncApplyService {
         tableInfo.setDatasourceId(datasourceId);
         tableInfo.setTableName(table.tableName());
         tableInfo.setPhysicalTableDescription(table.description());
+        tableInfo.setTableDescription(table.description());
         tableInfo.setDomain(SemanticConstants.DEFAULT_DOMAIN);
         tableInfo.setIsVisible(Boolean.TRUE);
         tableInfo.setPhysicalStatus(Boolean.TRUE);
@@ -367,6 +368,7 @@ public class SemanticSyncApplyService {
         columnInfo.setTableName(tableName);
         columnInfo.setColumnName(column.columnName());
         columnInfo.setPhysicalColumnDescription(column.description());
+        columnInfo.setColumnDescription(column.description());
         columnInfo.setTypeName(column.typeName());
         columnInfo.setPrimaryKey(column.primaryKey());
         columnInfo.setIndexInfo(column.indexInfo());

--- a/data-agent-backend/src/main/resources/mapper/ColumnSemanticInfoMapper.xml
+++ b/data-agent-backend/src/main/resources/mapper/ColumnSemanticInfoMapper.xml
@@ -129,6 +129,7 @@
         </foreach>
         ON DUPLICATE KEY UPDATE
             physical_column_description = VALUES(physical_column_description),
+            column_description = COALESCE(NULLIF(column_description, ''), VALUES(column_description)),
             type_name = VALUES(type_name),
             primary_key = VALUES(primary_key),
             index_info = VALUES(index_info),
@@ -154,6 +155,7 @@
             <if test="tableName != null">table_name = #{tableName},</if>
             <if test="columnName != null">column_name = #{columnName},</if>
             physical_column_description = #{physicalColumnDescription},
+            column_description = COALESCE(NULLIF(column_description, ''), #{columnDescription}),
             type_name = #{typeName},
             primary_key = #{primaryKey},
             index_info = #{indexInfo},

--- a/data-agent-backend/src/main/resources/mapper/TableInfoMapper.xml
+++ b/data-agent-backend/src/main/resources/mapper/TableInfoMapper.xml
@@ -111,6 +111,7 @@
         </foreach>
         ON DUPLICATE KEY UPDATE
             physical_table_description = VALUES(physical_table_description),
+            table_description = COALESCE(NULLIF(table_description, ''), VALUES(table_description)),
             physical_status = VALUES(physical_status),
             update_time = VALUES(update_time)
     </insert>
@@ -132,6 +133,7 @@
         <set>
             <if test="tableName != null">table_name = #{tableName},</if>
             physical_table_description = #{physicalTableDescription},
+            table_description = COALESCE(NULLIF(table_description, ''), #{tableDescription}),
             <if test="physicalStatus != null">physical_status = #{physicalStatus},</if>
             <if test="updateTime != null">update_time = #{updateTime},</if>
         </set>

--- a/data-agent-frontend/src/api/semantic.ts
+++ b/data-agent-frontend/src/api/semantic.ts
@@ -21,7 +21,6 @@ import type { PageResponse } from './domain';
 
 export interface PhysicalTableCandidateResponse {
   tableName: string;
-  physicalTableDescription: string | null;
   synced: boolean;
 }
 
@@ -29,7 +28,6 @@ export interface TableSemanticResponse {
   id: number | null;
   tableName: string;
   domain: string | null;
-  physicalTableDescription: string | null;
   tableDescription: string | null;
   isVisible: boolean;
   hasPhysicalTable: boolean;
@@ -42,7 +40,6 @@ export type TableSemanticInfo = TableSemanticResponse;
 export interface ColumnSemanticResponse {
   id: number | null;
   columnName: string;
-  physicalColumnDescription: string | null;
   columnDescription: string | null;
   typeName: string | null;
   primaryKey: boolean | null;

--- a/data-agent-frontend/src/composables/useAgentChat.ts
+++ b/data-agent-frontend/src/composables/useAgentChat.ts
@@ -182,16 +182,11 @@ export function useAgentChat(initialSessionId?: string) {
                 toolName: event.toolCall!.name,
                 question: (event.toolCall!.input[def.questionField] as string) ?? '',
               };
-              msg.isStreaming = false;
             }
 
             if (event.type === 'report') {
               lastReportContent.value = event.toolResult?.output ?? null;
             }
-          }
-
-          if (event.isLast) {
-            msg.isStreaming = false;
           }
         });
       }
@@ -199,7 +194,6 @@ export function useAgentChat(initialSessionId?: string) {
       if ((e as Error).name !== 'AbortError') {
         updateAgentMessage(agentMsg.id, msg => {
           msg.content = msg.content || `请求失败: ${(e as Error).message}`;
-          msg.isStreaming = false;
         });
       }
     } finally {

--- a/data-agent-frontend/src/views/chat/components/TracePanel.vue
+++ b/data-agent-frontend/src/views/chat/components/TracePanel.vue
@@ -133,7 +133,7 @@
       <span class="trace-panel__arrow">></span>
       <span class="trace-panel__dot"></span>
       <span v-if="message.isStreaming" class="trace-panel__spinner"></span>
-      <span class="trace-panel__title">{{ message.isStreaming ? '思考中' : '思维链' }}</span>
+      <span class="trace-panel__title">{{ message.isStreaming ? '思考中' : '思考完成' }}</span>
       <span class="trace-panel__summary">{{ summaryLabel }}</span>
     </div>
     <div v-show="isExpanded" class="trace-panel__body">

--- a/data-agent-frontend/src/views/semantic/components/ColumnSemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/ColumnSemanticManage.vue
@@ -27,6 +27,7 @@
     updateColumnSemantic,
     type ColumnSemanticInfo,
   } from '@/api/semantic';
+  import { formatDateTime } from '../utils';
 
   interface ColumnEditForm {
     tableName: string;
@@ -145,7 +146,7 @@
     Object.assign(form, {
       tableName: selectedTableName.value,
       columnName: row.columnName,
-      columnDescription: row.columnDescription ?? row.physicalColumnDescription ?? '',
+      columnDescription: row.columnDescription ?? '',
       isVisible: row.isVisible,
     });
     dialogVisible.value = true;
@@ -236,11 +237,6 @@
           {{ row.indexInfo || '-' }}
         </template>
       </el-table-column>
-      <el-table-column label="物理描述" min-width="180" show-overflow-tooltip>
-        <template #default="{ row }">
-          {{ row.physicalColumnDescription || '-' }}
-        </template>
-      </el-table-column>
       <el-table-column label="语义描述" min-width="180" show-overflow-tooltip>
         <template #default="{ row }">
           {{ row.columnDescription || '-' }}
@@ -272,7 +268,11 @@
           {{ row.invalidReason || '-' }}
         </template>
       </el-table-column>
-      <el-table-column prop="updateTime" label="更新时间" width="180" />
+      <el-table-column label="更新时间" width="180">
+        <template #default="{ row }">
+          {{ formatDateTime(row.updateTime) }}
+        </template>
+      </el-table-column>
       <el-table-column label="操作" width="150" fixed="right">
         <template #default="{ row }">
           <el-button link type="primary" size="small" @click="handleOpenEdit(row)">编辑</el-button>
@@ -324,7 +324,7 @@
             v-model="form.columnDescription"
             type="textarea"
             :rows="4"
-            placeholder="请输入列的语义描述信息（为空时将使用物理描述）"
+            placeholder="请输入列的语义描述信息"
           />
         </el-form-item>
         <el-form-item label="可见性" prop="isVisible" :error="fieldErrors.isVisible">

--- a/data-agent-frontend/src/views/semantic/components/DomainManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/DomainManage.vue
@@ -27,6 +27,7 @@
     deleteDomain,
     type DomainInfo,
   } from '@/api/domain';
+  import { formatDateTime } from '../utils';
 
   interface DomainEditForm {
     name: string;
@@ -63,6 +64,7 @@
 
   const domainRules: FormRules<DomainEditForm> = {
     name: [{ required: true, message: '领域名称不能为空', trigger: 'blur' }],
+    description: [{ required: true, whitespace: true, message: '域描述不能为空', trigger: 'blur' }],
   };
 
   const loadDomainPage = async () => {
@@ -133,7 +135,7 @@
     try {
       const payload = {
         name: domainForm.name.trim(),
-        description: domainForm.description.trim() || undefined,
+        description: domainForm.description.trim(),
       };
 
       if (selectedDomain.value) {
@@ -168,13 +170,6 @@
     }
   };
 
-  const formatTime = (value: string | null) => {
-    if (!value) {
-      return '-';
-    }
-    return value.replace('T', ' ');
-  };
-
   defineExpose({
     loadDomainPage,
   });
@@ -206,12 +201,12 @@
       </el-table-column>
       <el-table-column label="创建时间" width="180">
         <template #default="{ row }">
-          {{ formatTime(row.createTime) }}
+          {{ formatDateTime(row.createTime) }}
         </template>
       </el-table-column>
       <el-table-column label="更新时间" width="180">
         <template #default="{ row }">
-          {{ formatTime(row.updateTime) }}
+          {{ formatDateTime(row.updateTime) }}
         </template>
       </el-table-column>
       <el-table-column label="操作" width="180" fixed="right">

--- a/data-agent-frontend/src/views/semantic/components/RelationManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/RelationManage.vue
@@ -210,7 +210,7 @@
     return items.map(
       (item): RelationColumnNode => ({
         columnName: item.columnName,
-        description: item.columnDescription ?? item.physicalColumnDescription,
+        description: item.columnDescription,
         typeName: item.typeName,
         primaryKey: item.primaryKey,
         operable: item.effective,

--- a/data-agent-frontend/src/views/semantic/components/SyncPhysicalTableDialog.vue
+++ b/data-agent-frontend/src/views/semantic/components/SyncPhysicalTableDialog.vue
@@ -157,7 +157,7 @@
       <el-input
         v-model="keyword"
         clearable
-        placeholder="按表名或物理描述搜索"
+        placeholder="按表名搜索"
         @keyup.enter="loadCandidates"
       />
       <el-button @click="loadCandidates">查询</el-button>
@@ -171,11 +171,6 @@
     >
       <el-table-column type="selection" width="48" />
       <el-table-column prop="tableName" label="物理表名" min-width="220" />
-      <el-table-column label="物理描述" min-width="240" show-overflow-tooltip>
-        <template #default="{ row }">
-          {{ row.physicalTableDescription || '-' }}
-        </template>
-      </el-table-column>
       <el-table-column label="语义层" width="100" align="center">
         <template #default="{ row }">
           <el-tag :type="row.synced ? 'info' : 'success'" size="small">

--- a/data-agent-frontend/src/views/semantic/components/TableSemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/TableSemanticManage.vue
@@ -31,7 +31,7 @@
   } from '@/api/semantic';
   import ColumnSemanticManage from './ColumnSemanticManage.vue';
   import SyncPhysicalTableDialog from './SyncPhysicalTableDialog.vue';
-  import { buildSyncSummary, physicalStatusSyncSummaryFields } from '../utils';
+  import { buildSyncSummary, formatDateTime, physicalStatusSyncSummaryFields } from '../utils';
 
   interface TableEditForm {
     tableName: string;
@@ -142,7 +142,7 @@
     Object.assign(form, {
       tableName: row.tableName,
       domain: row.domain,
-      tableDescription: row.tableDescription ?? row.physicalTableDescription ?? '',
+      tableDescription: row.tableDescription ?? '',
       isVisible: row.isVisible,
     });
     // 加载领域选项
@@ -278,11 +278,6 @@
     <el-table v-loading="loading" :data="rows">
       <el-table-column prop="tableName" label="表名" min-width="150" />
       <el-table-column prop="domain" label="领域" min-width="120" />
-      <el-table-column label="物理描述" min-width="180" show-overflow-tooltip>
-        <template #default="{ row }">
-          {{ row.physicalTableDescription || '-' }}
-        </template>
-      </el-table-column>
       <el-table-column label="语义描述" min-width="180" show-overflow-tooltip>
         <template #default="{ row }">
           {{ row.tableDescription || '-' }}
@@ -303,7 +298,11 @@
         </template>
       </el-table-column>
 
-      <el-table-column prop="updateTime" label="更新时间" width="180" />
+      <el-table-column label="更新时间" width="180">
+        <template #default="{ row }">
+          {{ formatDateTime(row.updateTime) }}
+        </template>
+      </el-table-column>
       <el-table-column label="操作" width="220" fixed="right">
         <template #default="{ row }">
           <el-button link type="primary" size="small" @click="handleOpenEdit(row)">编辑</el-button>
@@ -372,7 +371,7 @@
             v-model="form.tableDescription"
             type="textarea"
             :rows="4"
-            placeholder="请输入表的语义描述信息（为空时将使用物理描述）"
+            placeholder="请输入表的语义描述信息"
           />
         </el-form-item>
         <el-form-item label="可见性" prop="isVisible" :error="fieldErrors.isVisible">

--- a/data-agent-frontend/src/views/semantic/utils.ts
+++ b/data-agent-frontend/src/views/semantic/utils.ts
@@ -56,3 +56,11 @@ export const buildSyncSummary = (
       return `${label} ${result[field]} ${unit}`;
     })
     .join('，');
+
+export const formatDateTime = (value: string | null | undefined) => {
+  if (!value) {
+    return '-';
+  }
+  const matched = value.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/);
+  return matched ? `${matched[1]} ${matched[2]}` : value.replace('T', ' ');
+};

--- a/skills/data-query/SKILL.md
+++ b/skills/data-query/SKILL.md
@@ -7,8 +7,8 @@ description: A skill for querying database tables and generating SQL queries bas
 
 You are a data query assistant. When the user asks a data-related question, follow these steps:
 
-1. Use the `get_domains` tool to get available data domains
-2. Based on the user's question, select the relevant domain(s), then use `get_tables(domains=[...])` to get tables in those domains
+1. Use the `get_domains` tool to get available data domains and their descriptions
+2. Based on the user's question, select the relevant domain name(s), then use `get_tables(domains=[...])` to get tables in those domains
 3. Use the `get_table_schema` tool to get the schema of relevant tables
 4. Generate a SELECT SQL statement based on the table structure
 5. Use the `execute_sql` tool to execute the query


### PR DESCRIPTION
- require domain descriptions on create and update
- initialize semantic descriptions from physical schema sync
- hide physical descriptions from frontend and agent prompt output
- keep thinking status until the full reply stream completes
- format semantic-layer timestamps as yyyy-MM-dd HH:mm:ss