### PR TITLE
refactor(frontend): consolidate semantic and system management pages

### DIFF
--- a/data-agent-frontend/src/components/common/HelpTip.vue
+++ b/data-agent-frontend/src/components/common/HelpTip.vue
@@ -1,0 +1,71 @@
+<!--
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ -->
+
+<script setup lang="ts">
+  withDefaults(
+    defineProps<{
+      placement?: string;
+    }>(),
+    {
+      placement: 'top',
+    },
+  );
+</script>
+
+<template>
+  <el-tooltip :placement="placement" effect="dark" popper-class="app-help-tip__popper">
+    <template #content>
+      <div class="app-help-tip__content">
+        <slot />
+      </div>
+    </template>
+    <span class="app-help-tip" aria-label="帮助说明" tabindex="0">?</span>
+  </el-tooltip>
+</template>
+
+<style>
+  .app-help-tip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--app-border);
+    border-radius: 50%;
+    color: var(--app-text-muted);
+    font-size: 12px;
+    line-height: 1;
+    cursor: help;
+    user-select: none;
+  }
+
+  .app-help-tip:hover,
+  .app-help-tip:focus {
+    color: var(--app-text-primary);
+    border-color: var(--app-text-secondary);
+    outline: none;
+  }
+
+  .app-help-tip__content {
+    max-width: 320px;
+    line-height: 1.7;
+  }
+
+  .app-help-tip__content ul {
+    margin: 4px 0 0 16px;
+  }
+</style>

--- a/data-agent-frontend/src/components/layout/AppSidebar.vue
+++ b/data-agent-frontend/src/components/layout/AppSidebar.vue
@@ -25,13 +25,11 @@
   const isCollapse = ref(false);
 
   const menuItems = [
-    { path: '/chat', title: 'AI 智能分析', icon: 'ChatDotRound' },
-    { path: '/data-source', title: '数据源管理', icon: 'Connection' },
-    { path: '/semantic', title: '语义管理', icon: 'Collection' },
-    { path: '/report', title: '报告管理', icon: 'Document' },
-    { path: '/metric', title: '指标口径管理', icon: 'DataLine' },
-    { path: '/sys-user', title: '用户管理', icon: 'User' },
-    { path: '/sys-role', title: '角色管理', icon: 'Avatar' },
+    { path: '/chat', title: 'AI 智能分析' },
+    { path: '/data-source', title: '数据源管理' },
+    { path: '/semantic', title: '语义管理' },
+    { path: '/report', title: '报告管理' },
+    { path: '/system', title: '系统管理' },
   ];
 
   const activeMenu = computed(() => route.path);

--- a/data-agent-frontend/src/router/index.ts
+++ b/data-agent-frontend/src/router/index.ts
@@ -62,22 +62,22 @@ const routes: RouteRecordRaw[] = [
     meta: { title: '报告管理' },
   },
   {
+    path: '/system',
+    name: 'SystemManage',
+    component: () => import('@/views/system/SystemManage.vue'),
+    meta: { title: '系统管理' },
+  },
+  {
     path: '/metric',
-    name: 'MetricManage',
-    component: () => import('@/views/metric/MetricManage.vue'),
-    meta: { title: '指标口径管理' },
+    redirect: '/semantic',
   },
   {
     path: '/sys-user',
-    name: 'UserManage',
-    component: () => import('@/views/sys-user/UserManage.vue'),
-    meta: { title: '用户管理' },
+    redirect: '/system?tab=user',
   },
   {
     path: '/sys-role',
-    name: 'RoleManage',
-    component: () => import('@/views/sys-role/RoleManage.vue'),
-    meta: { title: '角色管理' },
+    redirect: '/system?tab=role',
   },
 ];
 

--- a/data-agent-frontend/src/views/metric/MetricManage.vue
+++ b/data-agent-frontend/src/views/metric/MetricManage.vue
@@ -27,6 +27,7 @@
     type MetricInfo,
     type MetricUpsertRequest,
   } from '@/api/metric';
+  import { formatDateTime } from '@/views/semantic/utils';
 
   interface MetricEditForm {
     metricKey: string;
@@ -169,13 +170,6 @@
     }
   };
 
-  const formatTime = (value: string | null) => {
-    if (!value) {
-      return '-';
-    }
-    return value.replace('T', ' ');
-  };
-
   onMounted(() => {
     void loadMetrics();
   });
@@ -183,22 +177,8 @@
 
 <template>
   <div class="metric-page">
-    <section class="hero-card">
-      <div>
-        <h2 class="hero-title">指标口径管理</h2>
-        <p class="hero-desc">
-          定义业务指标的精确口径（度量、过滤、时间字段），供 Agent 在生成 SQL
-          时按名称或同义词检索使用。指标归属于当前活跃数据源。
-        </p>
-      </div>
-    </section>
-
-    <section class="content-card">
+    <section>
       <div class="section-header">
-        <div>
-          <h3>指标口径列表</h3>
-          <p>维护指标的度量表达式、过滤条件与时间字段口径。</p>
-        </div>
         <div class="section-header-actions">
           <el-input
             v-model="keyword"
@@ -241,7 +221,7 @@
         </el-table-column>
         <el-table-column label="更新时间" width="180">
           <template #default="{ row }">
-            {{ formatTime(row.updateTime) }}
+            {{ formatDateTime(row.updateTime) }}
           </template>
         </el-table-column>
         <el-table-column label="操作" width="160" fixed="right">
@@ -306,59 +286,14 @@
   .metric-page {
     display: flex;
     flex-direction: column;
-    gap: 20px;
-  }
-
-  .hero-card,
-  .content-card {
-    background: var(--app-bg-card);
-    border: 1px solid var(--app-border);
-    border-radius: 8px;
-    transition:
-      background-color 0.2s,
-      border-color 0.2s;
-  }
-
-  .hero-card {
-    padding: 24px 32px;
-    background: var(--app-gradient-hero);
-  }
-
-  .hero-title {
-    margin: 0 0 8px;
-    font-size: 20px;
-    color: var(--app-text-primary);
-    font-weight: 700;
-  }
-
-  .hero-desc {
-    max-width: 760px;
-    margin: 0;
-    color: var(--app-text-secondary);
-    line-height: 1.7;
-  }
-
-  .content-card {
-    padding: 24px;
   }
 
   .section-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: flex-start;
     gap: 16px;
     margin-bottom: 20px;
-  }
-
-  .section-header h3 {
-    font-size: 16px;
-    color: var(--app-text-primary);
-    margin-bottom: 6px;
-    font-weight: 600;
-  }
-
-  .section-header p {
-    color: var(--app-text-secondary);
   }
 
   .section-header-actions {

--- a/data-agent-frontend/src/views/semantic/SemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/SemanticManage.vue
@@ -49,7 +49,9 @@
             <span class="tab-label-with-help">
               数据领域管理
               <HelpTip>
-                <strong>数据领域</strong> 是业务主题分类，例如会员、订单、商品、售后。领域用于把表分组，帮助 AI 先判断该去哪些表里找数据。
+                <strong>数据领域</strong>
+                是业务主题分类，例如会员、订单、商品、售后。领域用于把表分组，帮助 AI
+                先判断该去哪些表里找数据。
               </HelpTip>
             </span>
           </template>
@@ -60,7 +62,9 @@
             <span class="tab-label-with-help">
               表语义管理
               <HelpTip>
-                <strong>表语义</strong> 说明一张物理表在业务上代表什么、属于哪个领域、是否允许被 AI 查询，以及它和其他表的逻辑关系。
+                <strong>表语义</strong>
+                说明一张物理表在业务上代表什么、属于哪个领域、是否允许被 AI
+                查询，以及它和其他表的逻辑关系。
               </HelpTip>
             </span>
           </template>
@@ -71,7 +75,9 @@
             <span class="tab-label-with-help">
               指标口径
               <HelpTip>
-                <strong>指标口径</strong> 是指标的统一计算规则。它定义业务叫法、同义词、聚合表达式、过滤条件和时间字段，供 Agent 生成 SQL 时检索使用。
+                <strong>指标口径</strong>
+                是指标的统一计算规则。它定义业务叫法、同义词、聚合表达式、过滤条件和时间字段，供
+                Agent 生成 SQL 时检索使用。
               </HelpTip>
             </span>
           </template>
@@ -82,7 +88,9 @@
             <span class="tab-label-with-help">
               逻辑外键
               <HelpTip>
-                <strong>逻辑外键</strong> 是语义层里的表关联说明。即使数据库没有真实外键，也可以告诉 AI 哪些字段能 join，减少乱连表。
+                <strong>逻辑外键</strong>
+                是语义层里的表关联说明。即使数据库没有真实外键，也可以告诉 AI 哪些字段能
+                join，减少乱连表。
               </HelpTip>
             </span>
           </template>

--- a/data-agent-frontend/src/views/semantic/SemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/SemanticManage.vue
@@ -16,26 +16,16 @@
  -->
 
 <script setup lang="ts">
-  import { computed, ref, watch } from 'vue';
+  import { ref, watch } from 'vue';
+  import HelpTip from '@/components/common/HelpTip.vue';
   import DomainManage from './components/DomainManage.vue';
+  import MetricManage from '@/views/metric/MetricManage.vue';
   import RelationManage from './components/RelationManage.vue';
   import TableSemanticManage from './components/TableSemanticManage.vue';
 
-  const activeTab = ref<'domain' | 'table' | 'relation'>('domain');
-  const keyword = ref('');
-  const sortOrder = ref<'asc' | 'desc'>('asc');
+  const activeTab = ref<'domain' | 'table' | 'metric' | 'relation'>('domain');
   const domainManageRef = ref<InstanceType<typeof DomainManage>>();
   const tableManageRef = ref<InstanceType<typeof TableSemanticManage>>();
-
-  const showSearchToolbar = computed(() => activeTab.value === 'domain');
-
-  const handleSearch = async () => {
-    if (activeTab.value === 'domain' && domainManageRef.value) {
-      await domainManageRef.value.loadDomainPage();
-    } else if (activeTab.value === 'table' && tableManageRef.value) {
-      await tableManageRef.value.loadPage();
-    }
-  };
 
   watch(activeTab, async tab => {
     if (tab === 'domain' && domainManageRef.value) {
@@ -48,47 +38,54 @@
 
 <template>
   <div class="semantic-page">
-    <section class="hero-card">
-      <div>
-        <h2 class="hero-title">语义管理</h2>
-        <p class="hero-desc">
-          统一管理数据领域、表语义、列语义和逻辑外键配置，用于分类和组织表结构。
-        </p>
-      </div>
-    </section>
-
-    <section v-if="showSearchToolbar" class="toolbar-card">
-      <div class="toolbar-grid">
-        <el-input
-          v-model="keyword"
-          class="toolbar-field"
-          clearable
-          placeholder="按领域名称搜索"
-          @keyup.enter="handleSearch"
-        />
-        <el-segmented
-          v-model="sortOrder"
-          :options="[
-            { label: '名称升序', value: 'asc' },
-            { label: '名称降序', value: 'desc' },
-          ]"
-          @change="handleSearch"
-        />
-        <div class="toolbar-actions">
-          <el-button type="primary" @click="handleSearch">查询</el-button>
-        </div>
-      </div>
-    </section>
+    <div class="page-header">
+      <h2 class="page-title">语义管理</h2>
+    </div>
 
     <section class="content-card">
       <el-tabs v-model="activeTab" class="semantic-tabs">
-        <el-tab-pane label="数据领域管理" name="domain">
-          <DomainManage ref="domainManageRef" :keyword="keyword" :sort-order="sortOrder" />
+        <el-tab-pane name="domain">
+          <template #label>
+            <span class="tab-label-with-help">
+              数据领域管理
+              <HelpTip>
+                <strong>数据领域</strong> 是业务主题分类，例如会员、订单、商品、售后。领域用于把表分组，帮助 AI 先判断该去哪些表里找数据。
+              </HelpTip>
+            </span>
+          </template>
+          <DomainManage ref="domainManageRef" keyword="" sort-order="asc" />
         </el-tab-pane>
-        <el-tab-pane label="表语义管理" name="table">
-          <TableSemanticManage ref="tableManageRef" :keyword="keyword" :sort-order="sortOrder" />
+        <el-tab-pane name="table">
+          <template #label>
+            <span class="tab-label-with-help">
+              表语义管理
+              <HelpTip>
+                <strong>表语义</strong> 说明一张物理表在业务上代表什么、属于哪个领域、是否允许被 AI 查询，以及它和其他表的逻辑关系。
+              </HelpTip>
+            </span>
+          </template>
+          <TableSemanticManage ref="tableManageRef" keyword="" sort-order="asc" />
         </el-tab-pane>
-        <el-tab-pane label="逻辑外键" name="relation">
+        <el-tab-pane name="metric">
+          <template #label>
+            <span class="tab-label-with-help">
+              指标口径
+              <HelpTip>
+                <strong>指标口径</strong> 是指标的统一计算规则。它定义业务叫法、同义词、聚合表达式、过滤条件和时间字段，供 Agent 生成 SQL 时检索使用。
+              </HelpTip>
+            </span>
+          </template>
+          <MetricManage />
+        </el-tab-pane>
+        <el-tab-pane name="relation">
+          <template #label>
+            <span class="tab-label-with-help">
+              逻辑外键
+              <HelpTip>
+                <strong>逻辑外键</strong> 是语义层里的表关联说明。即使数据库没有真实外键，也可以告诉 AI 哪些字段能 join，减少乱连表。
+              </HelpTip>
+            </span>
+          </template>
           <RelationManage />
         </el-tab-pane>
       </el-tabs>
@@ -103,64 +100,36 @@
     gap: 20px;
   }
 
-  .hero-card,
-  .toolbar-card,
   .content-card {
     background: var(--app-bg-card);
     border: 1px solid var(--app-border);
     border-radius: 8px;
+    padding: 24px;
     transition:
       background-color 0.2s,
       border-color 0.2s;
   }
 
-  .hero-card {
-    padding: 24px 32px;
-    background: var(--app-gradient-hero);
-  }
-
-  .hero-title {
-    margin: 0 0 8px;
-    font-size: 20px;
-    color: var(--app-text-primary);
-    font-weight: 700;
-  }
-
-  .hero-desc {
-    max-width: 720px;
-    margin: 0;
-    color: var(--app-text-secondary);
-    line-height: 1.7;
-  }
-
-  .toolbar-card,
-  .content-card {
-    padding: 24px;
-  }
-
-  .toolbar-grid {
-    display: grid;
-    grid-template-columns: minmax(240px, 1fr) auto auto;
-    gap: 16px;
+  .page-header {
+    display: flex;
+    justify-content: space-between;
     align-items: center;
   }
 
-  .toolbar-field {
-    width: 100%;
+  .page-title {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--app-text-primary);
   }
 
-  .toolbar-actions {
-    display: flex;
-    gap: 12px;
+  .tab-label-with-help {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
 
   .semantic-tabs :deep(.el-tabs__header) {
     margin-bottom: 24px;
-  }
-
-  @media (max-width: 1024px) {
-    .toolbar-grid {
-      grid-template-columns: 1fr;
-    }
   }
 </style>

--- a/data-agent-frontend/src/views/semantic/components/ColumnSemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/ColumnSemanticManage.vue
@@ -211,7 +211,6 @@
     <div class="section-header">
       <div>
         <h3>列语义列表</h3>
-        <p>管理和维护物理列的业务语义信息。</p>
       </div>
       <el-tag type="primary" effect="plain">共 {{ page.total }} 列</el-tag>
     </div>
@@ -353,10 +352,6 @@
     color: var(--app-text-primary);
     margin-bottom: 6px;
     font-weight: 600;
-  }
-
-  .section-header p {
-    color: var(--app-text-secondary);
   }
 
   .error-banner {

--- a/data-agent-frontend/src/views/semantic/components/DomainManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/DomainManage.vue
@@ -182,10 +182,6 @@
 <template>
   <section class="table-panel">
     <div class="section-header">
-      <div>
-        <h3>数据领域列表</h3>
-        <p>管理全局数据领域标签，可用于表语义配置。</p>
-      </div>
       <div class="section-header-actions">
         <el-button type="primary" @click="handleOpenDomainCreate">新增领域</el-button>
         <el-tag type="primary" effect="plain">共 {{ domainPage.total }} 个领域</el-tag>
@@ -263,21 +259,10 @@
 <style scoped>
   .section-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: flex-start;
     gap: 16px;
     margin-bottom: 20px;
-  }
-
-  .section-header h3 {
-    font-size: 16px;
-    color: var(--app-text-primary);
-    margin-bottom: 6px;
-    font-weight: 600;
-  }
-
-  .section-header p {
-    color: var(--app-text-secondary);
   }
 
   .section-header-actions {

--- a/data-agent-frontend/src/views/semantic/components/RelationManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/RelationManage.vue
@@ -19,7 +19,6 @@
   import { computed, onMounted, reactive, ref, watch } from 'vue';
   import { ElMessage, ElMessageBox } from 'element-plus';
   import { useDatasource } from '@/composables/useDatasource';
-  import type { DatasourceResponse } from '@/api/datasource';
   import { useFieldErrors } from '@/composables/useFieldErrors';
   import {
     createLogicalRelation,
@@ -73,6 +72,7 @@
   const relationNodes = ref<TableNodeLayout[]>([]);
   const relationRecords = ref<LogicalTableRelationResponse[]>([]);
   const selectedRelation = ref<LogicalTableRelationResponse | null>(null);
+  const relationWorkspaceRef = ref<InstanceType<typeof RelationWorkspace>>();
   const relationLoadToken = ref(0);
   const workspacePage = reactive({
     page: 1,
@@ -99,10 +99,6 @@
   const relationTargetColumns = ref<RelationColumnNode[]>([]);
   const suppressRelationTableWatch = ref(false);
   const suppressDatasourceWatch = ref(false);
-
-  const activeDatasource = computed<DatasourceResponse | undefined>(() =>
-    datasourceList.value.find(item => item.id === selectedDatasourceId.value),
-  );
 
   const canQuery = computed(() => typeof selectedDatasourceId.value === 'number');
 
@@ -546,6 +542,10 @@
     resetRelationForm();
   }
 
+  function handleResetViewport() {
+    relationWorkspaceRef.value?.resetViewport();
+  }
+
   onMounted(() => {
     void initializeDatasource();
   });
@@ -566,17 +566,6 @@
 
 <template>
   <div class="relation-manage-page">
-    <section class="hero-card">
-      <div>
-        <h2 class="hero-title">逻辑外键管理</h2>
-        <p class="hero-desc">维护表间关系，支持在 ER 图中直接查看和拖拽创建逻辑外键。</p>
-      </div>
-      <div class="hero-meta">
-        <span>当前数据源</span>
-        <strong>{{ activeDatasource?.name ?? '未选择' }}</strong>
-      </div>
-    </section>
-
     <section class="toolbar-card">
       <div class="toolbar-grid">
         <el-select
@@ -594,13 +583,7 @@
           />
         </el-select>
         <div class="toolbar-actions">
-          <el-button
-            type="primary"
-            :loading="relationLoading || relationNodeLoading"
-            @click="loadRelationData"
-          >
-            刷新关系
-          </el-button>
+          <el-button @click="handleResetViewport">重置视图</el-button>
         </div>
       </div>
       <div v-if="datasourceError" class="error-tip">
@@ -610,6 +593,7 @@
 
     <section class="content-card">
       <RelationWorkspace
+        ref="relationWorkspaceRef"
         :loading="relationLoading"
         :node-loading="relationNodeLoading"
         :relation-error="relationError"
@@ -617,7 +601,6 @@
         :nodes="relationNodes"
         :relations="relationRecords"
         :draft-relation="draftRelation"
-        @refresh="loadRelationData"
         @edit-relation="handleEditRelation"
         @delete-relation="handleDeleteRelation"
         @toggle-relation-enabled="handleToggleRelationEnabled"
@@ -662,63 +645,15 @@
     gap: 20px;
   }
 
-  .hero-card,
   .toolbar-card,
   .content-card {
     background: var(--app-bg-card);
     border: 1px solid var(--app-border);
     border-radius: 8px;
-    transition:
-      background-color 0.2s,
-      border-color 0.2s;
-  }
-
-  .hero-card {
-    display: flex;
-    justify-content: space-between;
-    gap: 24px;
-    padding: 24px 32px;
-    background: var(--app-gradient-hero);
-  }
-
-  .hero-title {
-    margin: 0 0 8px;
-    color: var(--app-text-primary);
-    font-size: 20px;
-    font-weight: 700;
-  }
-
-  .hero-desc {
-    max-width: 680px;
-    margin: 0;
-    color: var(--app-text-secondary);
-    line-height: 1.7;
-  }
-
-  .hero-meta {
-    min-width: 180px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: 16px 20px;
-    border-radius: 8px;
-    background: var(--app-bg-page);
-    border: 1px solid var(--app-border);
-    color: var(--app-text-secondary);
-    transition:
-      background-color 0.2s,
-      border-color 0.2s;
-  }
-
-  .hero-meta strong {
-    margin-top: 6px;
-    color: var(--app-text-primary);
-    font-size: 16px;
-  }
-
-  .toolbar-card,
-  .content-card {
     padding: 24px;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
   }
 
   .toolbar-grid {
@@ -749,10 +684,6 @@
   }
 
   @media (max-width: 1024px) {
-    .hero-card {
-      flex-direction: column;
-    }
-
     .toolbar-grid {
       grid-template-columns: 1fr;
     }

--- a/data-agent-frontend/src/views/semantic/components/RelationWorkspace.vue
+++ b/data-agent-frontend/src/views/semantic/components/RelationWorkspace.vue
@@ -81,7 +81,6 @@
   }>();
 
   const emit = defineEmits<{
-    (event: 'refresh'): void;
     (event: 'edit-relation', relation: LogicalTableRelationResponse): void;
     (event: 'delete-relation', relation: LogicalTableRelationResponse): void;
     (
@@ -652,21 +651,14 @@
     }
     return 'success';
   }
+
+  defineExpose({
+    resetViewport,
+  });
 </script>
 
 <template>
   <section class="relation-panel">
-    <div class="section-header">
-      <div>
-        <h3>逻辑外键 ER 图</h3>
-        <p>滚轮缩放，空白区拖动画布，从字段拖到字段创建关系。</p>
-      </div>
-      <div class="relation-actions">
-        <el-button @click="resetViewport">重置视图</el-button>
-        <el-button :loading="loading || nodeLoading" @click="emit('refresh')">刷新关系图</el-button>
-      </div>
-    </div>
-
     <div class="relation-layout">
       <div
         ref="viewportRef"
@@ -835,13 +827,6 @@
           <button class="canvas-ctrl-btn" title="缩小" @click.stop="zoomOut">-</button>
           <span class="canvas-ctrl-label">{{ zoomPercent }}%</span>
           <button class="canvas-ctrl-btn" title="放大" @click.stop="zoomIn">+</button>
-          <button
-            class="canvas-ctrl-btn canvas-ctrl-fit"
-            title="适应画布"
-            @click.stop="resetViewport"
-          >
-            []
-          </button>
         </div>
       </div>
 
@@ -921,30 +906,6 @@
     display: flex;
     flex-direction: column;
     gap: 16px;
-  }
-
-  .section-header {
-    display: flex;
-    justify-content: space-between;
-    gap: 16px;
-    align-items: flex-start;
-  }
-
-  .section-header h3 {
-    margin: 0 0 4px;
-    color: var(--app-text-primary);
-    font-size: 16px;
-    font-weight: 600;
-  }
-
-  .section-header p {
-    margin: 0;
-    color: var(--app-text-secondary);
-  }
-
-  .relation-actions {
-    display: flex;
-    gap: 12px;
   }
 
   .relation-layout {
@@ -1228,12 +1189,6 @@
     text-align: center;
     color: var(--app-text-secondary);
     font-size: 12px;
-  }
-
-  .canvas-ctrl-fit {
-    margin-left: 4px;
-    border-left: 1px solid var(--app-border);
-    padding-left: 4px;
   }
 
   @media (max-width: 1280px) {

--- a/data-agent-frontend/src/views/semantic/components/TableSemanticManage.vue
+++ b/data-agent-frontend/src/views/semantic/components/TableSemanticManage.vue
@@ -258,10 +258,6 @@
 <template>
   <section class="table-panel">
     <div class="section-header">
-      <div>
-        <h3>表语义列表</h3>
-        <p>管理和维护物理表的业务语义信息。</p>
-      </div>
       <div class="header-actions">
         <el-tag type="primary" effect="plain">共 {{ page.total }} 张表</el-tag>
         <el-button :loading="refreshingPhysicalStatus" @click="handleRefreshPhysicalStatus">
@@ -409,7 +405,7 @@
 <style scoped>
   .section-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: flex-start;
     gap: 16px;
     margin-bottom: 20px;
@@ -419,17 +415,6 @@
     display: flex;
     align-items: center;
     gap: 12px;
-  }
-
-  .section-header h3 {
-    font-size: 16px;
-    color: var(--app-text-primary);
-    margin-bottom: 6px;
-    font-weight: 600;
-  }
-
-  .section-header p {
-    color: var(--app-text-secondary);
   }
 
   .error-banner {

--- a/data-agent-frontend/src/views/sys-role/RoleManage.vue
+++ b/data-agent-frontend/src/views/sys-role/RoleManage.vue
@@ -23,6 +23,7 @@
   import { getDatasourceList, type DatasourceResponse } from '@/api/datasource';
   import type { RoleResponse } from '@/api/sysRole';
   import request from '@/api/request';
+  import { formatDateTime } from '@/views/semantic/utils';
 
   const loading = ref(false);
   const roles = ref<RoleResponse[]>([]);
@@ -214,8 +215,7 @@
 
 <template>
   <div class="role-manage-page">
-    <div class="page-header">
-      <h2>角色管理</h2>
+    <div class="table-actions">
       <el-button type="primary" @click="openCreate">新建角色</el-button>
     </div>
 
@@ -223,6 +223,11 @@
       <el-table-column prop="id" label="ID" width="70" align="center" />
       <el-table-column prop="name" label="角色名称" min-width="140" />
       <el-table-column prop="description" label="描述" min-width="200" show-overflow-tooltip />
+      <el-table-column label="创建时间" width="180" align="center">
+        <template #default="{ row }">
+          {{ formatDateTime(row.createTime) }}
+        </template>
+      </el-table-column>
       <el-table-column label="操作" width="240" align="center" fixed="right">
         <template #default="{ row }">
           <el-button size="small" @click="openEdit(row)">编辑</el-button>
@@ -354,18 +359,13 @@
 
 <style scoped>
   .role-manage-page {
-    max-width: 900px;
+    width: 100%;
   }
-  .page-header {
+  .table-actions {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 16px;
-  }
-  .page-header h2 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--app-text-primary);
+    justify-content: flex-end;
+    gap: 12px;
+    margin-bottom: 20px;
   }
 </style>

--- a/data-agent-frontend/src/views/sys-user/UserManage.vue
+++ b/data-agent-frontend/src/views/sys-user/UserManage.vue
@@ -22,6 +22,7 @@
   import * as sysUserApi from '@/api/sysUser';
   import { listRoles, type RoleResponse } from '@/api/sysRole';
   import type { UserResponse } from '@/api/sysUser';
+  import { formatDateTime } from '@/views/semantic/utils';
 
   const loading = ref(false);
   const users = ref<UserResponse[]>([]);
@@ -166,8 +167,7 @@
 
 <template>
   <div class="user-manage-page">
-    <div class="page-header">
-      <h2>用户管理</h2>
+    <div class="table-actions">
       <el-button type="primary" @click="openCreate">新建用户</el-button>
     </div>
 
@@ -189,7 +189,11 @@
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column prop="createTime" label="创建时间" width="180" align="center" />
+      <el-table-column label="创建时间" width="180" align="center">
+        <template #default="{ row }">
+          {{ formatDateTime(row.createTime) }}
+        </template>
+      </el-table-column>
       <el-table-column label="操作" width="280" align="center" fixed="right">
         <template #default="{ row }">
           <el-button size="small" @click="openEdit(row)">编辑</el-button>
@@ -285,20 +289,14 @@
 
 <style scoped>
   .user-manage-page {
-    max-width: 1200px;
+    width: 100%;
   }
 
-  .page-header {
+  .table-actions {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 16px;
-  }
-
-  .page-header h2 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--app-text-primary);
+    justify-content: flex-end;
+    gap: 12px;
+    margin-bottom: 20px;
   }
 </style>

--- a/data-agent-frontend/src/views/system/SystemManage.vue
+++ b/data-agent-frontend/src/views/system/SystemManage.vue
@@ -1,0 +1,100 @@
+<!--
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ -->
+
+<script setup lang="ts">
+  import { ref, watch } from 'vue';
+  import { useRoute, useRouter } from 'vue-router';
+  import RoleManage from '@/views/sys-role/RoleManage.vue';
+  import UserManage from '@/views/sys-user/UserManage.vue';
+
+  type SystemTab = 'user' | 'role';
+
+  const route = useRoute();
+  const router = useRouter();
+  const activeTab = ref<SystemTab>(resolveTab(route.query.tab));
+
+  function resolveTab(value: unknown): SystemTab {
+    return value === 'role' ? 'role' : 'user';
+  }
+
+  watch(
+    () => route.query.tab,
+    tab => {
+      activeTab.value = resolveTab(tab);
+    },
+  );
+
+  watch(activeTab, tab => {
+    if (route.query.tab !== tab) {
+      router.replace({ path: '/system', query: { tab } });
+    }
+  });
+</script>
+
+<template>
+  <div class="system-page">
+    <div class="page-header">
+      <h2 class="page-title">系统管理</h2>
+    </div>
+
+    <section class="content-card">
+      <el-tabs v-model="activeTab" class="system-tabs">
+        <el-tab-pane label="用户管理" name="user">
+          <UserManage />
+        </el-tab-pane>
+        <el-tab-pane label="角色管理" name="role">
+          <RoleManage />
+        </el-tab-pane>
+      </el-tabs>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+  .system-page {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .content-card {
+    background: var(--app-bg-card);
+    border: 1px solid var(--app-border);
+    border-radius: 8px;
+    padding: 24px;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s;
+  }
+
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .page-title {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--app-text-primary);
+  }
+
+  .system-tabs :deep(.el-tabs__header) {
+    margin-bottom: 24px;
+  }
+</style>


### PR DESCRIPTION
- move metric definitions into semantic management tabs
- group user and role pages under system management
- trim duplicate headings, descriptions, and relation graph controls
- reuse shared date formatting across management tables