### PR TITLE
refactor(metric): match caliber by scanning question for metric terms

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetMetricCaliberTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetMetricCaliberTool.java
@@ -37,17 +37,18 @@ public class GetMetricCaliberTool implements MarkAgentTool {
                     """
                     Get the precise business caliber (definition) of a metric when you are unsure \
                     how it should be computed — which measure expression to use, which time field \
-                    to apply, or whether test data should be excluded. Pass a natural-language \
-                    description of the metric (e.g. "流水", "销售额", "复购率"), and it returns the \
-                    metric's measure expression, filters, time field and caliber notes. Call this \
-                    whenever the exact caliber of a mentioned metric is unclear before generating SQL.\
+                    to apply, or whether test data should be excluded. It returns the metric's \
+                    measure expression, filters, time field and caliber notes. Call this whenever \
+                    the exact caliber of a mentioned metric is unclear before generating SQL. \
+                    You may pass the user's question verbatim: the matcher scans the question for \
+                    known metric names and aliases, so there is no need to distill it to a keyword.\
                     """)
     public String getMetricCaliber(
             @ToolParam(
                             name = "hint",
                             description =
-                                    "Natural-language description of the metric, e.g. 流水 / 销售额 /"
-                                            + " 复购率")
+                                    "A metric name, or the user's question verbatim, e.g. 流水 /"
+                                            + " 销售额 / 上个月的GMV是多少")
                     String hint) {
         try {
             return metricService.getCaliberByHint(hint);

--- a/data-agent-backend/src/main/java/io/github/malonetalk/mapper/MetricInfoMapper.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/mapper/MetricInfoMapper.java
@@ -43,9 +43,6 @@ public interface MetricInfoMapper {
 
     List<MetricInfo> selectAllByDatasource(@Param("datasourceId") Integer datasourceId);
 
-    List<MetricInfo> matchByHint(
-            @Param("datasourceId") Integer datasourceId, @Param("hint") String hint);
-
     List<MetricInfo> suggest(
             @Param("datasourceId") Integer datasourceId, @Param("limit") int limit);
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/service/MetricServiceImpl.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/service/MetricServiceImpl.java
@@ -21,8 +21,12 @@ import io.github.malonetalk.entity.MetricInfo;
 import io.github.malonetalk.mapper.MetricInfoMapper;
 import io.github.malonetalk.utils.SemanticUtils;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +35,10 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MetricServiceImpl implements MetricService {
+
+    private static final int MIN_TERM_LENGTH = 2;
+    private static final int MAX_CANDIDATES = 3;
+    private static final String ALIAS_SEPARATORS = "[,，、;；/|]";
 
     private final MetricInfoMapper metricInfoMapper;
     private final DatasourceService datasourceService;
@@ -45,21 +53,65 @@ public class MetricServiceImpl implements MetricService {
     @Override
     public String getCaliberByHint(String hint) {
         Integer dsId = activeDatasourceId();
-        String normalized = SemanticUtils.trimToNull(hint);
-        if (normalized == null) {
+        String query = SemanticUtils.trimToNull(hint);
+        if (query == null) {
             return "缺少指标描述,无法查询口径。";
         }
-        List<MetricInfo> candidates = metricInfoMapper.matchByHint(dsId, normalized);
+        List<MetricInfo> candidates = match(metricInfoMapper.selectAllByDatasource(dsId), query);
         if (candidates.isEmpty()) {
             List<MetricInfo> suggestions = metricInfoMapper.suggest(dsId, 5);
-            log.warn("指标口径未命中: hint={}", normalized);
-            return formatNotFound(normalized, suggestions);
+            log.warn("指标口径未命中: hint={}", query);
+            return formatNotFound(query, suggestions);
         }
         MetricInfo best = candidates.get(0);
         if (candidates.size() == 1) {
             return best.toCaliberText();
         }
         return formatCaliberWithAlternatives(best, candidates.subList(1, candidates.size()));
+    }
+
+    /**
+     * 反向包含匹配:拿指标的每个名字去用户的话里找,而不是拿整句话去别名串里找。
+     * 后者要求模型先把问题提炼成干净的指标名,而它通常直接把用户原话整句传进来,必然落空。
+     * 多个指标命中时按「命中的词有多长」降序——命中"销售额"比命中"额"可信。
+     *
+     */
+    static List<MetricInfo> match(List<MetricInfo> metrics, String query) {
+        return metrics.stream()
+                .map(m -> new Hit(m, longestMatchedTerm(m, query)))
+                .filter(Hit::matched)
+                .sorted(Comparator.comparingInt(Hit::length).reversed())
+                .limit(MAX_CANDIDATES)
+                .map(Hit::metric)
+                .toList();
+    }
+
+    private static int longestMatchedTerm(MetricInfo metric, String query) {
+        return termsOf(metric).stream()
+                .filter(term -> SemanticUtils.containsIgnoreCase(query, term))
+                .mapToInt(String::length)
+                .max()
+                .orElse(0);
+    }
+
+    /** name + aliases 拆成候选词。过短的别名(如"额")会误伤大量无关问句,直接丢弃。 */
+    private static List<String> termsOf(MetricInfo metric) {
+        Stream<String> aliases =
+                metric.getAliases() == null
+                        ? Stream.empty()
+                        : Arrays.stream(metric.getAliases().split(ALIAS_SEPARATORS));
+        return Stream.concat(Stream.of(metric.getName()), aliases)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(term -> term.length() >= MIN_TERM_LENGTH)
+                .distinct()
+                .toList();
+    }
+
+    private record Hit(MetricInfo metric, int length) {
+        boolean matched() {
+            return length > 0;
+        }
     }
 
     private String formatNotFound(String hint, List<MetricInfo> suggestions) {

--- a/data-agent-backend/src/main/resources/mapper/MetricInfoMapper.xml
+++ b/data-agent-backend/src/main/resources/mapper/MetricInfoMapper.xml
@@ -46,28 +46,9 @@
         ORDER BY name ASC, id ASC
     </select>
 
-    <!-- 命中:精确 name 优先,其次 aliases/description 包含提示词。
-         metric_key 仅作程序化引用(供 skill/API 直接 getByKey),不参与自然语言匹配。
-         匹配大小写不敏感靠 LOWER();本表排序规则为 utf8mb4_unicode_ci(_ci 已大小写不敏感),
-         故 LOWER 在此冗余但无害——若换 _bin 库仍可兜底。
-         性能:datasource_id 复合索引先把候选集砍到单个数据源(数十~数百行),
-         段内逐行 LIKE 可接受;前导通配符 '%x%' 与 LOWER(列) 会使 aliases/description 索引用不上,
-         但候选集已极小,无需优化。仅当指标膨胀到成千上万条时再改 FULLTEXT 索引。 -->
-    <select id="matchByHint" resultMap="BaseResultMap">
-        SELECT * FROM metric_info
-        WHERE datasource_id = #{datasourceId}
-          AND is_deleted = 0
-          AND (
-            LOWER(name) = LOWER(#{hint})
-            OR LOWER(aliases) LIKE CONCAT('%', LOWER(#{hint}), '%')
-            OR LOWER(description) LIKE CONCAT('%', LOWER(#{hint}), '%')
-          )
-        ORDER BY
-          CASE WHEN LOWER(name) = LOWER(#{hint})
-               THEN 0 ELSE 1 END,
-          id ASC
-    </select>
-
+    <!-- 命中逻辑已移到 MetricServiceImpl#match:拿指标的 name/aliases 去用户的话里做包含判断,
+         而不是拿整句话到别名串里 LIKE——模型传进来的通常是用户原话整句,后者必然落空。
+         metric_key 仅作程序化引用(供 skill/API 直接 getByKey),不参与自然语言匹配。 -->
     <select id="suggest" resultMap="BaseResultMap">
         SELECT * FROM metric_info
         WHERE datasource_id = #{datasourceId}

--- a/data-agent-backend/src/test/java/io/github/malonetalk/service/MetricServiceImplTest.java
+++ b/data-agent-backend/src/test/java/io/github/malonetalk/service/MetricServiceImplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 github.com/MaloneTalk
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * limitations under the License.
+ */
+package io.github.malonetalk.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.malonetalk.entity.MetricInfo;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MetricServiceImplTest {
+
+    @Test
+    void matchesMetricWhenHintIsTheFullQuestion() {
+        List<MetricInfo> metrics = List.of(metric("销售额", "流水,GMV,营收"));
+
+        assertEquals(List.of("销售额"), names(MetricServiceImpl.match(metrics, "上个月的GMV是多少")));
+    }
+
+    @Test
+    void matchesCaseInsensitive() {
+        List<MetricInfo> metrics = List.of(metric("销售额", "GMV"));
+
+        assertEquals(List.of("销售额"), names(MetricServiceImpl.match(metrics, "上个月的gmv多少")));
+    }
+
+    @Test
+    void ignoresSingleCharacterAliases() {
+        List<MetricInfo> metrics = List.of(metric("销售额", "额"));
+
+        assertTrue(MetricServiceImpl.match(metrics, "账户余额还剩多少").isEmpty());
+    }
+
+    @Test
+    void ranksLongerMatchFirst() {
+        List<MetricInfo> metrics = List.of(metric("销售", null), metric("销售额", null));
+
+        assertEquals(List.of("销售额", "销售"), names(MetricServiceImpl.match(metrics, "查一下销售额")));
+    }
+
+    @Test
+    void returnsEmptyWhenNoTermAppears() {
+        List<MetricInfo> metrics = List.of(metric("销售额", "GMV"));
+
+        assertTrue(MetricServiceImpl.match(metrics, "华东区有多少家门店").isEmpty());
+    }
+
+    @Test
+    void toleratesNullNameAndAliases() {
+        List<MetricInfo> metrics = List.of(new MetricInfo());
+
+        assertTrue(MetricServiceImpl.match(metrics, "销售额").isEmpty());
+    }
+
+    private static MetricInfo metric(String name, String aliases) {
+        MetricInfo metric = new MetricInfo();
+        metric.setName(name);
+        metric.setAliases(aliases);
+        return metric;
+    }
+
+    private static List<String> names(List<MetricInfo> metrics) {
+        return metrics.stream().map(MetricInfo::getName).toList();
+    }
+}


### PR DESCRIPTION
related #135 
Replace the SQL LIKE matcher (matchByHint) with in-memory reverse matching in MetricServiceImpl#match: each metric's name/aliases are tokenized and looked up inside the user's question, case-insensitively. The model often passes the question verbatim, which the old LIKE %question% never matched. Short aliases (<2 chars) are dropped to avoid false hits; top-3 ranked by matched-term length. Tool description now invites passing the raw question. Adds unit tests.