### PR TITLE
feat(agent): remind model to confirm metric caliber before writing SQL

### DIFF
--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTableSchemaTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTableSchemaTool.java
@@ -59,7 +59,8 @@ public class GetTableSchemaTool implements MarkAgentTool {
                             columnSemanticService.getMergedTableSchema(
                                     datasource.getId(), tableName);
                     return ToolResultBlock.text(
-                            SemanticUtils.formatTableSchema(tableName, columns));
+                            SemanticUtils.formatTableSchema(tableName, columns)
+                                    + ToolCallConstants.METRIC_CALIBER_REMINDER);
                 });
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTablesTool.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/GetTablesTool.java
@@ -63,9 +63,10 @@ public class GetTablesTool implements MarkAgentTool {
                             dataSourceService.getDatasourceForSession(ctx.sessionId());
                     return ToolResultBlock.text(
                             JsonUtils.getJsonCodec()
-                                    .toJson(
-                                            tableSemanticService.listMergedTablesByDomains(
-                                                    dataSource.getId(), domains)));
+                                            .toJson(
+                                                    tableSemanticService.listMergedTablesByDomains(
+                                                            dataSource.getId(), domains))
+                                    + ToolCallConstants.METRIC_CALIBER_REMINDER);
                 });
     }
 }

--- a/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/ToolCallConstants.java
+++ b/data-agent-backend/src/main/java/io/github/malonetalk/agent/tools/ToolCallConstants.java
@@ -29,6 +29,18 @@ public final class ToolCallConstants {
 
     public static final String SUCCESS = "SUCCESS";
 
+    /**
+     * 追加在 get_tables / get_table_schema 的返回结果末尾。模型写 SQL 前基本必看表结构,
+     * 在那个时机提醒「先确认指标口径」比在 system prompt 里说更准——此时它正准备动笔。
+     * 数据源没定义任何指标时,get_metric_caliber 会回「未定义」,模型自然跳过。
+     */
+    public static final String METRIC_CALIBER_REMINDER =
+            """
+
+            If the question involves a business metric, call get_metric_caliber to confirm its \
+            caliber before writing SQL.\
+            """;
+
     public static final String SEPARATOR = ": ";
 
     public static final String SUCCESS_PREFIX = SUCCESS + SEPARATOR;


### PR DESCRIPTION
related  #135 

Append METRIC_CALIBER_REMINDER to get_tables / get_table_schema output: the model reads table structure right before composing SQL, so prompting there beats the system prompt. If the datasource defines no metrics, get_metric_caliber simply reports none and the model moves on.